### PR TITLE
demo: chunking and planning using Cline+Gemini 2.5 pro

### DIFF
--- a/demo/step-1.md
+++ b/demo/step-1.md
@@ -1,0 +1,87 @@
+## Problem Statement
+
+We have a working OpenAPI spec for a Social Network app and we want to introduce a new resource: “Likes”
+
+### Initialize memory bank
+
+- Start by prompting to initialize the bank
+
+>Prompt (ACT):
+>
+>initialize memory bank
+
+- Empty templates are scaffolded
+
+### Provide the necessary context on the project and the requirements
+
+- Stay in PLAN mode and begin providing the necessary context
+
+>Prompt (PLAN):
+>
+>This project contains a @/README.md that provides an overview over what it is. There is a backend in Golang and a Frontend in React.
+>
+>One important aspect of this project is that it follows OpenAPI specification to design and provide standards around how the endpoints are built and what contracts are exposed to the user, which in our case for now is only the Frontend.
+>
+>However, in the future we can consider exposing these endpoints to clients too (we are already following a versioning convention to avoid breaking changes).
+>
+>The specs are defined in @/openapi - we write partials that are then recomposed together to generate a final spec, the latest one is @/openapi/openapi-bundled.yaml
+>
+>We have not yet implemented a strategy on how to produce and persist different bundles that can represent snapshots of our API spec at different points in time. This will be needed and is a missing feature to implement in the future.
+>
+>A more immediate requirement we have is the definition of a new endpoint. This endpoint should expose "likes".
+>
+>I have shared a lot of context with you so far, some of which I believe should be saved in our memory bank.
+>Regarding the new endpoint implementation, let's begin a discussion on how it should be structured - keeping in mind we can lean on the existing patterns and conventions of the existing openapi spec.
+
+- The model will generate a plan - review it and if happy - select ACT mode.
+- The model will begin updating the memory bank.
+- Review the files that have been created.
+
+### Review initial plan draft in the memory bank
+
+- We start in [systemPatterns.md](../memory-bank/systemPatterns.md) where we see some critical findings discovered by Cline, particularly in "Key Technical Decisions"
+  - Cline discovered that we have codegen for API types
+  - Cline discovered that we use the /v1/ path versioning
+  - Cline discovered we use structured response for Success and Errors
+
+We didn't directly provide them with this information, but it's now available context for the model, and extremely relevant to our task.
+
+- In [techContext.md](../memory-bank/techContext.md) Cline identified the usage of some important scripts from the Makefile.
+
+- In [activeContext.md](../memory-bank/activeContext.md) what Cline considers to be the plan:
+
+- We see some redundancy across [projectbrief.md](../memory-bank/projectbrief.md) and [productContext.md](../memory-bank/productContext.md) - we will address that if we start seeing results that conflict with the content of those files.
+
+```
+## Next Steps
+
+- Complete updates for `systemPatterns.md`, `techContext.md`, and `progress.md`.
+- Discuss the requirements and design for the new "likes" endpoint.
+- Define the OpenAPI specification for the "likes" endpoint.
+- Implement the backend logic for "likes".
+- Implement the frontend UI and logic for "likes".
+```
+
+- ***Scope creep***: The model is assuming we want to implement the full functionality - including UI and BE logic in our plan.
+
+- The model needs guidance to avoid tackling backend (BE) and frontend (FE) development before finalizing the API specification, similar to how a junior developer might try to do everything simultaneously. 
+
+
+### Let's Chunk the Plan
+
+> Prompt (PLAN):
+> The context you saved and identified appears mostly correct. However we need to adjust the Next steps:
+>
+> - Complete updates for systemPatterns.md, techContext.md, and progress.md.
+> - Discuss the requirements and design for the new "likes" endpoint.
+> - Define the OpenAPI specification for the "likes" endpoint.
+> - Implement the backend logic for "likes".
+> - Implement the frontend UI and logic for "likes".
+>
+> The implementation of the feature should be out of scope - we are only interested in the endpoint API Spec at this stage, and we consider this work "Done" once we have a valid OpenAPI spec that we can load to our current Swagger UI. The Swagger UI is already functional and will automatically pick updates to the spec.
+>
+> Implement versioning of the bundled spec is also out of scope for now.
+>
+> Let's update our plan to reflect these requirements.
+
+We are now ready for Step 2.

--- a/demo/step-2.md
+++ b/demo/step-2.md
@@ -1,0 +1,54 @@
+# Step 2: Designing the Likes API Specification
+
+After refining our plan in Step 1, we now need to design the OpenAPI specification for the new "Likes" resource, focusing solely on the API contract without implementation details.
+
+## Review Current Plan
+
+- We've reviewed the plan in [Active Context](../memory-bank/activeContext.md) and confirmed our approach
+- The plan now correctly focuses on the OpenAPI specification only, with implementation being out of scope
+
+## Chunking the Task
+
+***Task Decomposition*** - By chunking the task, the model receives critical hints that transform the initially vague request, "Define the OpenAPI specification for the 'likes' endpoint," into a concrete series of steps, resulting in a smaller, more manageable scope.
+
+We see in the active context that these steps are now very clearly defined:
+
+```yaml
+3.  Create/update the necessary OpenAPI partial files (e.g., new schemas in `openapi/shared/schemas/` or `openapi/v1/schemas/`, new paths in `openapi/v1/paths/`).
+4.  Update `openapi/openapi.yaml` to reference the new "likes" paths and schemas.
+5.  Run `make generate-types` (or at least the `redocly bundle` part) to create an updated `openapi/openapi-bundled.yaml`.
+```
+
+***Providing Specific Context*** - By providing specific details about the file structure and build process, the model can automatically understand the necessary steps without requiring additional clarification.
+
+## Defining the Data Model
+
+Now that the model knows how to proceed, we need to define what to create. Switch back to PLAN mode and provide a concrete data model to constrain the AI's response:
+
+> Prompt (PLAN):
+> 
+> I would like the likes endpoint to follow the current REST conventions of the project. The Likes data model should have the following shape:
+> 
+> ```go
+> // Like represents a user's like on a post or comment.
+> type Like struct {
+> 	ID        string    `json:"id"`         // Unique identifier for the like
+> 	UserID    string    `json:"user_id"`    // ID of the user who liked the content
+> 	PostID    *string   `json:"post_id,omitempty"`   // ID of the post being liked (nullable)
+> 	CommentID *string   `json:"comment_id,omitempty"` // ID of the comment being liked (nullable)
+> 	CreatedAt time.Time `json:"created_at"` // Timestamp when the like was created
+> }
+> ```
+> 
+> PostID and CommentID are made nullable (using pointers in Go, *string) because a single Like entry represents a user liking either a post or a comment, but not both simultaneously.
+> 
+> Generate an initial spec that we can discuss and iterate together
+> // Expected output: OpenAPI schema definition for the Like resource
+
+## Review Implementation
+
+- After receiving the initial specification, we switch to ACT mode to update the memory bank, ensuring the design decisions are preserved across contexts.
+
+> Prompt (ACT):
+> 
+> Can we add this plan to the memory bank so that I can review it across contexts to make sure we are making the right decisions?

--- a/demo/step-3.md
+++ b/demo/step-3.md
@@ -1,0 +1,42 @@
+# Step 3: Refining the API Specification
+
+After designing the initial specification for the "Likes" endpoint, we need to address some inconsistencies and ambiguities before finalizing the OpenAPI specification.
+
+## Review of Initial Specification
+
+We now have a fully developed specification in [activeContext.md](../memory-bank/activeContext.md), but the model has identified several important considerations that need clarification.
+
+## Identifying Inconsistencies
+
+***Proactive Validation*** - The model identified potential inconsistencies between our provided example and existing codebase patterns, demonstrating how AI can help detect issues early in the design process.
+
+```markdown
+**Discussion Points for this Proposal:**
+1.  **ID Types:** Confirm if `Like` related IDs (`id`, `user_id`, `post_id`, `comment_id`) should be `string` (as per Go struct) or `integer` (like other entities).
+2.  **Listing Likes Content:** Is an array of full `Like` objects suitable for `GET` requests, or would a list of user IDs/count be preferred in some cases?
+3.  **Common Error Responses:** Ensure `#/components/responses/*` refs point to correctly defined shared responses.
+```
+
+This highlights the importance of planning and review before implementation, as the model detected a practice violation in an example provided to it.
+
+## Providing Clarification
+
+***Structured Feedback*** - By addressing each point directly and providing clear guidance, we help the model make informed decisions that align with existing patterns and best practices.
+
+> Prompt (ACT):
+> 
+> Your proposal raises important questions here:
+> 
+> Discussion Points for this Proposal:
+> 1. ID Types: Confirm if `Like` related IDs (`id`, `user_id`, `post_id`, `comment_id`) should be `string` (as per Go struct) or `integer` (like other entities).
+> 2. Listing Likes Content: Is an array of full `Like` objects suitable for `GET` requests, or would a list of user IDs/count be preferred in some cases?
+> 3. Common Error Responses: Ensure `#/components/responses/*` refs point to correctly defined shared responses.
+>
+> Feedback:
+> 1. Stick to integer for consistency - these are PSQL auto-incrementing integers
+> 2. Let's have an array of likes as object.
+> 3. You should use the existing schema. If an existing schema doesn't exist, we should introduce one that is backwards compatible with the existing specs.
+>
+> Update the plan based on my feedback.
+
+***Point-by-Point Addressing*** - By responding to each numbered point in the model's questions with corresponding numbered answers, we create a clear mapping between questions and answers that minimizes ambiguity.

--- a/demo/step-4.md
+++ b/demo/step-4.md
@@ -1,0 +1,4 @@
+# Step 5 - Finalize the implementation plan
+
+We have now toggled ACT mode on the final plan. All clarifications have been answered, and we are happy with the plan outlined in [activeContext.md](../memory-bank/activeContext.md).
+

--- a/demo/step-5.md
+++ b/demo/step-5.md
@@ -1,0 +1,24 @@
+# Step 5: Executing the Implementation Plan
+
+## Transitioning to Action
+
+We have now toggled ACT mode on the final plan. All clarifications have been answered, and we are happy with the plan outlined in [activeContext.md](../memory-bank/activeContext.md).
+
+## Leveraging Agentic Capabilities
+
+***Autonomous Execution*** - This is now the start of Agentic mode - Cline will begin running commands and updating files without requiring step-by-step guidance for each action.
+
+Impressively, the system not only generated the necessary types but also automatically updated the API specification by utilizing CLI tooling. This process ensured the auto-generation and updating of existing types. *(Check Git Dff updates)*
+
+***Tool Detection and Usage*** - The model automatically detected which CLI commands to run based on the project context, demonstrating its ability to understand development workflows without explicit instructions.
+
+## Feedback Loop Implementation
+
+***Self-Correction Mechanism*** - The model will feed back to itself any errors in types generation and continue to iterate over the specification until it meets all requirements.
+
+***Continuous Memory Updates*** - I will be assisting with the prompting to continuously update the memory bank for every discovery, ensuring that important context is preserved throughout the implementation process.
+
+**Assist in Debugging** - Provide feedback to the model when errors are encountered, and help debug issues by providing context and guidance.
+> Prompt(ACT)
+>
+>It looks good, but I don't see the new paths exposed in Swagger UI - I suspect it might have something to do with @/openapi/openapi.yaml not having the new `paths` linked correctly?

--- a/demo/step-6.md
+++ b/demo/step-6.md
@@ -1,0 +1,9 @@
+# Step 6: Agentic Troubleshooting and auto-fixing
+
+The model correctly identified the next step to get unblocked and fix the current issues. However, before proceeding, it's important to ensure the context is up-to-date in memory.
+
+> Prompt (ACT)
+>
+>Your plan looks good, but before we begin, I want to make sure our memory bank is up to date with the state of our progress.
+
+*(See git diff for the fixes)*

--- a/demo/step-7.md
+++ b/demo/step-7.md
@@ -1,0 +1,29 @@
+# Step 7: Verification and Task Completion
+
+## Final Implementation Review
+
+Cline confirmed the implementation has terminated successfully. The final step in our process is to verify the results and formally complete the task.
+
+***Verification Process*** - We verify that the CLI generation of types completed successfully, and Cline itself proactively prompts to launch the browser at the Swagger UI page to check the new "likes" endpoint.
+
+*(Check Swagger UI)*
+
+## Continuous Knowledge Preservation
+
+***Memory Management*** - The memory bank continues to be updated throughout this process, ensuring that all important discoveries and decisions are preserved for future reference.
+
+## Task Completion and Documentation
+
+***Formal Closure*** - Once we're happy with the result, we can confirm completion to update the memory bank with another prompt, creating a clear endpoint to the task:
+
+> Prompt (ACT):
+>
+> I consider the task completed. We can update our memory bank
+
+## Key Takeaways from the Process
+
+***Iterative Development*** - The entire process demonstrated how breaking down a complex task into manageable steps leads to successful implementation.
+
+***Effective Collaboration*** - The combination of human guidance and AI capabilities created a powerful workflow that leveraged the strengths of both.
+
+***Documentation Value*** - By maintaining comprehensive documentation in the memory bank throughout the process, we've created a valuable resource for future development work.

--- a/frontend/src/generated/api-types.ts
+++ b/frontend/src/generated/api-types.ts
@@ -223,6 +223,68 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/posts/{postId}/likes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the post. */
+                postId: number;
+            };
+            cookie?: never;
+        };
+        /**
+         * List likes for a post
+         * @description Retrieves a list of likes for a specific post.
+         */
+        get: operations["listPostLikesV1"];
+        put?: never;
+        /**
+         * Like a post
+         * @description Creates a new like on a specific post for the authenticated user.
+         */
+        post: operations["createPostLikeV1"];
+        /**
+         * Unlike a post
+         * @description Removes the authenticated user's like from a specific post.
+         */
+        delete: operations["deletePostLikeV1"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/comments/{commentId}/likes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the comment. */
+                commentId: number;
+            };
+            cookie?: never;
+        };
+        /**
+         * List likes for a comment
+         * @description Retrieves a list of likes for a specific comment.
+         */
+        get: operations["listCommentLikesV1"];
+        put?: never;
+        /**
+         * Like a comment
+         * @description Creates a new like on a specific comment for the authenticated user.
+         */
+        post: operations["createCommentLikeV1"];
+        /**
+         * Unlike a comment
+         * @description Removes the authenticated user's like from a specific comment.
+         */
+        delete: operations["deleteCommentLikeV1"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -1403,6 +1465,320 @@ export interface operations {
                 };
             };
             /** @description Server error deleting comment. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+        };
+    };
+    listPostLikesV1: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the post. */
+                postId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description A list of likes retrieved successfully. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ListLikesSuccessResponse"];
+                };
+            };
+            /** @description Authentication required or invalid token. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Post not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server error retrieving likes. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+        };
+    };
+    createPostLikeV1: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the post. */
+                postId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Post liked successfully. Returns the created like object. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateLikeSuccessResponse"];
+                };
+            };
+            /** @description Authentication required or invalid token. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Post not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Post already liked by the user or other conflict. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server error creating like. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+        };
+    };
+    deletePostLikeV1: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the post. */
+                postId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Post unliked successfully. No content returned. */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Authentication required or invalid token. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Post not found or like not found for the user. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server error deleting like. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+        };
+    };
+    listCommentLikesV1: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the comment. */
+                commentId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description A list of likes retrieved successfully. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ListLikesSuccessResponse"];
+                };
+            };
+            /** @description Authentication required or invalid token. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Comment not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server error retrieving likes. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+        };
+    };
+    createCommentLikeV1: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the comment. */
+                commentId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Comment liked successfully. Returns the created like object. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateLikeSuccessResponse"];
+                };
+            };
+            /** @description Authentication required or invalid token. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Comment not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Comment already liked by the user or other conflict. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server error creating like. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+        };
+    };
+    deleteCommentLikeV1: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the comment. */
+                commentId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Comment unliked successfully. No content returned. */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Authentication required or invalid token. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Comment not found or like not found for the user. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiErrorResponse"];
+                };
+            };
+            /** @description Server error deleting like. */
             500: {
                 headers: {
                     [name: string]: unknown;

--- a/frontend/src/generated/api-types.ts
+++ b/frontend/src/generated/api-types.ts
@@ -500,6 +500,47 @@ export interface components {
             /** @description An array of comment objects. */
             data: components["schemas"]["Comment"][];
         };
+        /** @description Represents a user's like on a post or comment. One of post_id or comment_id should be populated. */
+        Like: {
+            /**
+             * Format: int64
+             * @description Unique identifier for the like.
+             * @example 1001
+             */
+            readonly id: number;
+            /**
+             * Format: int64
+             * @description ID of the user who liked the content.
+             * @example 101
+             */
+            readonly user_id: number;
+            /**
+             * Format: int64
+             * @description ID of the post being liked (mutually exclusive with comment_id).
+             * @example 201
+             */
+            post_id?: number | null;
+            /**
+             * Format: int64
+             * @description ID of the comment being liked (mutually exclusive with post_id).
+             * @example 301
+             */
+            comment_id?: number | null;
+            /**
+             * Format: date-time
+             * @description Timestamp when the like was created.
+             * @example 2024-03-10T10:30:00Z
+             */
+            readonly created_at: string;
+        };
+        /** @description Standard wrapper for the successful like creation response. */
+        CreateLikeSuccessResponse: {
+            data: components["schemas"]["Like"];
+        };
+        /** @description Standard wrapper for listing likes. */
+        ListLikesSuccessResponse: {
+            data: components["schemas"]["Like"][];
+        };
         /** @description Standard wrapper for the successful signup response. */
         SignupSuccessResponse: {
             /** @description Contains the created user object. */

--- a/internal/generated/types.go
+++ b/internal/generated/types.go
@@ -78,6 +78,12 @@ type CreateCommentSuccessResponse struct {
 	Data Comment `json:"data"`
 }
 
+// CreateLikeSuccessResponse Standard wrapper for the successful like creation response.
+type CreateLikeSuccessResponse struct {
+	// Data Represents a user's like on a post or comment. One of post_id or comment_id should be populated.
+	Data Like `json:"data"`
+}
+
 // CreatePostRequest Data required to create a new post.
 type CreatePostRequest struct {
 	// Content The text content of the post.
@@ -108,10 +114,33 @@ type GetUserProfileSuccessResponse struct {
 	Data User `json:"data"`
 }
 
+// Like Represents a user's like on a post or comment. One of post_id or comment_id should be populated.
+type Like struct {
+	// CommentId ID of the comment being liked (mutually exclusive with post_id).
+	CommentId *int64 `json:"comment_id"`
+
+	// CreatedAt Timestamp when the like was created.
+	CreatedAt *time.Time `json:"created_at,omitempty"`
+
+	// Id Unique identifier for the like.
+	Id *int64 `json:"id,omitempty"`
+
+	// PostId ID of the post being liked (mutually exclusive with comment_id).
+	PostId *int64 `json:"post_id"`
+
+	// UserId ID of the user who liked the content.
+	UserId *int64 `json:"user_id,omitempty"`
+}
+
 // ListCommentsSuccessResponse Standard wrapper for the successful comment list retrieval response.
 type ListCommentsSuccessResponse struct {
 	// Data An array of comment objects.
 	Data []Comment `json:"data"`
+}
+
+// ListLikesSuccessResponse Standard wrapper for listing likes.
+type ListLikesSuccessResponse struct {
+	Data []Like `json:"data"`
 }
 
 // ListPostsSuccessResponse Standard wrapper for the successful post list retrieval response.
@@ -365,6 +394,15 @@ type ClientInterface interface {
 
 	SignupUserV1(ctx context.Context, body SignupUserV1JSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
+	// DeleteCommentLikeV1 request
+	DeleteCommentLikeV1(ctx context.Context, commentId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListCommentLikesV1 request
+	ListCommentLikesV1(ctx context.Context, commentId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreateCommentLikeV1 request
+	CreateCommentLikeV1(ctx context.Context, commentId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// ListPostsV1 request
 	ListPostsV1(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -402,6 +440,15 @@ type ClientInterface interface {
 	UpdateCommentV1WithBody(ctx context.Context, postId int64, id int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	UpdateCommentV1(ctx context.Context, postId int64, id int64, body UpdateCommentV1JSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// DeletePostLikeV1 request
+	DeletePostLikeV1(ctx context.Context, postId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ListPostLikesV1 request
+	ListPostLikesV1(ctx context.Context, postId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// CreatePostLikeV1 request
+	CreatePostLikeV1(ctx context.Context, postId int64, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetUserProfileV1 request
 	GetUserProfileV1(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -474,6 +521,42 @@ func (c *Client) SignupUserV1WithBody(ctx context.Context, contentType string, b
 
 func (c *Client) SignupUserV1(ctx context.Context, body SignupUserV1JSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewSignupUserV1Request(c.Server, body)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) DeleteCommentLikeV1(ctx context.Context, commentId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeleteCommentLikeV1Request(c.Server, commentId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListCommentLikesV1(ctx context.Context, commentId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListCommentLikesV1Request(c.Server, commentId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreateCommentLikeV1(ctx context.Context, commentId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreateCommentLikeV1Request(c.Server, commentId)
 	if err != nil {
 		return nil, err
 	}
@@ -652,6 +735,42 @@ func (c *Client) UpdateCommentV1(ctx context.Context, postId int64, id int64, bo
 	return c.Client.Do(req)
 }
 
+func (c *Client) DeletePostLikeV1(ctx context.Context, postId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewDeletePostLikeV1Request(c.Server, postId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) ListPostLikesV1(ctx context.Context, postId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListPostLikesV1Request(c.Server, postId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) CreatePostLikeV1(ctx context.Context, postId int64, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewCreatePostLikeV1Request(c.Server, postId)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
 func (c *Client) GetUserProfileV1(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewGetUserProfileV1Request(c.Server)
 	if err != nil {
@@ -818,6 +937,108 @@ func NewSignupUserV1RequestWithBody(server string, contentType string, body io.R
 	}
 
 	req.Header.Add("Content-Type", contentType)
+
+	return req, nil
+}
+
+// NewDeleteCommentLikeV1Request generates requests for DeleteCommentLikeV1
+func NewDeleteCommentLikeV1Request(server string, commentId int64) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "commentId", runtime.ParamLocationPath, commentId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/comments/%s/likes", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListCommentLikesV1Request generates requests for ListCommentLikesV1
+func NewListCommentLikesV1Request(server string, commentId int64) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "commentId", runtime.ParamLocationPath, commentId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/comments/%s/likes", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreateCommentLikeV1Request generates requests for CreateCommentLikeV1
+func NewCreateCommentLikeV1Request(server string, commentId int64) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "commentId", runtime.ParamLocationPath, commentId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/comments/%s/likes", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
 
 	return req, nil
 }
@@ -1221,6 +1442,108 @@ func NewUpdateCommentV1RequestWithBody(server string, postId int64, id int64, co
 	return req, nil
 }
 
+// NewDeletePostLikeV1Request generates requests for DeletePostLikeV1
+func NewDeletePostLikeV1Request(server string, postId int64) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "postId", runtime.ParamLocationPath, postId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/posts/%s/likes", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("DELETE", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewListPostLikesV1Request generates requests for ListPostLikesV1
+func NewListPostLikesV1Request(server string, postId int64) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "postId", runtime.ParamLocationPath, postId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/posts/%s/likes", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewCreatePostLikeV1Request generates requests for CreatePostLikeV1
+func NewCreatePostLikeV1Request(server string, postId int64) (*http.Request, error) {
+	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "postId", runtime.ParamLocationPath, postId)
+	if err != nil {
+		return nil, err
+	}
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/v1/posts/%s/likes", pathParam0)
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewGetUserProfileV1Request generates requests for GetUserProfileV1
 func NewGetUserProfileV1Request(server string) (*http.Request, error) {
 	var err error
@@ -1347,6 +1670,15 @@ type ClientWithResponsesInterface interface {
 
 	SignupUserV1WithResponse(ctx context.Context, body SignupUserV1JSONRequestBody, reqEditors ...RequestEditorFn) (*SignupUserV1Response, error)
 
+	// DeleteCommentLikeV1WithResponse request
+	DeleteCommentLikeV1WithResponse(ctx context.Context, commentId int64, reqEditors ...RequestEditorFn) (*DeleteCommentLikeV1Response, error)
+
+	// ListCommentLikesV1WithResponse request
+	ListCommentLikesV1WithResponse(ctx context.Context, commentId int64, reqEditors ...RequestEditorFn) (*ListCommentLikesV1Response, error)
+
+	// CreateCommentLikeV1WithResponse request
+	CreateCommentLikeV1WithResponse(ctx context.Context, commentId int64, reqEditors ...RequestEditorFn) (*CreateCommentLikeV1Response, error)
+
 	// ListPostsV1WithResponse request
 	ListPostsV1WithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListPostsV1Response, error)
 
@@ -1384,6 +1716,15 @@ type ClientWithResponsesInterface interface {
 	UpdateCommentV1WithBodyWithResponse(ctx context.Context, postId int64, id int64, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateCommentV1Response, error)
 
 	UpdateCommentV1WithResponse(ctx context.Context, postId int64, id int64, body UpdateCommentV1JSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateCommentV1Response, error)
+
+	// DeletePostLikeV1WithResponse request
+	DeletePostLikeV1WithResponse(ctx context.Context, postId int64, reqEditors ...RequestEditorFn) (*DeletePostLikeV1Response, error)
+
+	// ListPostLikesV1WithResponse request
+	ListPostLikesV1WithResponse(ctx context.Context, postId int64, reqEditors ...RequestEditorFn) (*ListPostLikesV1Response, error)
+
+	// CreatePostLikeV1WithResponse request
+	CreatePostLikeV1WithResponse(ctx context.Context, postId int64, reqEditors ...RequestEditorFn) (*CreatePostLikeV1Response, error)
 
 	// GetUserProfileV1WithResponse request
 	GetUserProfileV1WithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*GetUserProfileV1Response, error)
@@ -1483,6 +1824,81 @@ func (r SignupUserV1Response) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r SignupUserV1Response) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type DeleteCommentLikeV1Response struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON401      *ApiErrorResponse
+	JSON404      *ApiErrorResponse
+	JSON500      *ApiErrorResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r DeleteCommentLikeV1Response) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeleteCommentLikeV1Response) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListCommentLikesV1Response struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ListLikesSuccessResponse
+	JSON401      *ApiErrorResponse
+	JSON404      *ApiErrorResponse
+	JSON500      *ApiErrorResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r ListCommentLikesV1Response) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListCommentLikesV1Response) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CreateCommentLikeV1Response struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *CreateLikeSuccessResponse
+	JSON401      *ApiErrorResponse
+	JSON404      *ApiErrorResponse
+	JSON409      *ApiErrorResponse
+	JSON500      *ApiErrorResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r CreateCommentLikeV1Response) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreateCommentLikeV1Response) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -1743,6 +2159,81 @@ func (r UpdateCommentV1Response) StatusCode() int {
 	return 0
 }
 
+type DeletePostLikeV1Response struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON401      *ApiErrorResponse
+	JSON404      *ApiErrorResponse
+	JSON500      *ApiErrorResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r DeletePostLikeV1Response) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r DeletePostLikeV1Response) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ListPostLikesV1Response struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *ListLikesSuccessResponse
+	JSON401      *ApiErrorResponse
+	JSON404      *ApiErrorResponse
+	JSON500      *ApiErrorResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r ListPostLikesV1Response) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ListPostLikesV1Response) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type CreatePostLikeV1Response struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON201      *CreateLikeSuccessResponse
+	JSON401      *ApiErrorResponse
+	JSON404      *ApiErrorResponse
+	JSON409      *ApiErrorResponse
+	JSON500      *ApiErrorResponse
+}
+
+// Status returns HTTPResponse.Status
+func (r CreatePostLikeV1Response) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r CreatePostLikeV1Response) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
 type GetUserProfileV1Response struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -1843,6 +2334,33 @@ func (c *ClientWithResponses) SignupUserV1WithResponse(ctx context.Context, body
 		return nil, err
 	}
 	return ParseSignupUserV1Response(rsp)
+}
+
+// DeleteCommentLikeV1WithResponse request returning *DeleteCommentLikeV1Response
+func (c *ClientWithResponses) DeleteCommentLikeV1WithResponse(ctx context.Context, commentId int64, reqEditors ...RequestEditorFn) (*DeleteCommentLikeV1Response, error) {
+	rsp, err := c.DeleteCommentLikeV1(ctx, commentId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeleteCommentLikeV1Response(rsp)
+}
+
+// ListCommentLikesV1WithResponse request returning *ListCommentLikesV1Response
+func (c *ClientWithResponses) ListCommentLikesV1WithResponse(ctx context.Context, commentId int64, reqEditors ...RequestEditorFn) (*ListCommentLikesV1Response, error) {
+	rsp, err := c.ListCommentLikesV1(ctx, commentId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListCommentLikesV1Response(rsp)
+}
+
+// CreateCommentLikeV1WithResponse request returning *CreateCommentLikeV1Response
+func (c *ClientWithResponses) CreateCommentLikeV1WithResponse(ctx context.Context, commentId int64, reqEditors ...RequestEditorFn) (*CreateCommentLikeV1Response, error) {
+	rsp, err := c.CreateCommentLikeV1(ctx, commentId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreateCommentLikeV1Response(rsp)
 }
 
 // ListPostsV1WithResponse request returning *ListPostsV1Response
@@ -1965,6 +2483,33 @@ func (c *ClientWithResponses) UpdateCommentV1WithResponse(ctx context.Context, p
 		return nil, err
 	}
 	return ParseUpdateCommentV1Response(rsp)
+}
+
+// DeletePostLikeV1WithResponse request returning *DeletePostLikeV1Response
+func (c *ClientWithResponses) DeletePostLikeV1WithResponse(ctx context.Context, postId int64, reqEditors ...RequestEditorFn) (*DeletePostLikeV1Response, error) {
+	rsp, err := c.DeletePostLikeV1(ctx, postId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseDeletePostLikeV1Response(rsp)
+}
+
+// ListPostLikesV1WithResponse request returning *ListPostLikesV1Response
+func (c *ClientWithResponses) ListPostLikesV1WithResponse(ctx context.Context, postId int64, reqEditors ...RequestEditorFn) (*ListPostLikesV1Response, error) {
+	rsp, err := c.ListPostLikesV1(ctx, postId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseListPostLikesV1Response(rsp)
+}
+
+// CreatePostLikeV1WithResponse request returning *CreatePostLikeV1Response
+func (c *ClientWithResponses) CreatePostLikeV1WithResponse(ctx context.Context, postId int64, reqEditors ...RequestEditorFn) (*CreatePostLikeV1Response, error) {
+	rsp, err := c.CreatePostLikeV1(ctx, postId, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseCreatePostLikeV1Response(rsp)
 }
 
 // GetUserProfileV1WithResponse request returning *GetUserProfileV1Response
@@ -2126,6 +2671,147 @@ func ParseSignupUserV1Response(rsp *http.Response) (*SignupUserV1Response, error
 			return nil, err
 		}
 		response.JSON400 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest ApiErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest ApiErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseDeleteCommentLikeV1Response parses an HTTP response from a DeleteCommentLikeV1WithResponse call
+func ParseDeleteCommentLikeV1Response(rsp *http.Response) (*DeleteCommentLikeV1Response, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeleteCommentLikeV1Response{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest ApiErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ApiErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest ApiErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListCommentLikesV1Response parses an HTTP response from a ListCommentLikesV1WithResponse call
+func ParseListCommentLikesV1Response(rsp *http.Response) (*ListCommentLikesV1Response, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListCommentLikesV1Response{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ListLikesSuccessResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest ApiErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ApiErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest ApiErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreateCommentLikeV1Response parses an HTTP response from a CreateCommentLikeV1WithResponse call
+func ParseCreateCommentLikeV1Response(rsp *http.Response) (*CreateCommentLikeV1Response, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreateCommentLikeV1Response{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest CreateLikeSuccessResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest ApiErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ApiErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
 		var dest ApiErrorResponse
@@ -2644,6 +3330,147 @@ func ParseUpdateCommentV1Response(rsp *http.Response) (*UpdateCommentV1Response,
 	return response, nil
 }
 
+// ParseDeletePostLikeV1Response parses an HTTP response from a DeletePostLikeV1WithResponse call
+func ParseDeletePostLikeV1Response(rsp *http.Response) (*DeletePostLikeV1Response, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &DeletePostLikeV1Response{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest ApiErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ApiErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest ApiErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseListPostLikesV1Response parses an HTTP response from a ListPostLikesV1WithResponse call
+func ParseListPostLikesV1Response(rsp *http.Response) (*ListPostLikesV1Response, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ListPostLikesV1Response{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest ListLikesSuccessResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest ApiErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ApiErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest ApiErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseCreatePostLikeV1Response parses an HTTP response from a CreatePostLikeV1WithResponse call
+func ParseCreatePostLikeV1Response(rsp *http.Response) (*CreatePostLikeV1Response, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &CreatePostLikeV1Response{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
+		var dest CreateLikeSuccessResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON201 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 401:
+		var dest ApiErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON401 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest ApiErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest ApiErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
+		var dest ApiErrorResponse
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON500 = &dest
+
+	}
+
+	return response, nil
+}
+
 // ParseGetUserProfileV1Response parses an HTTP response from a GetUserProfileV1WithResponse call
 func ParseGetUserProfileV1Response(rsp *http.Response) (*GetUserProfileV1Response, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -2752,6 +3579,15 @@ type ServerInterface interface {
 	// Sign up a new user
 	// (POST /v1/auth/signup)
 	SignupUserV1(ctx echo.Context) error
+	// Unlike a comment
+	// (DELETE /v1/comments/{commentId}/likes)
+	DeleteCommentLikeV1(ctx echo.Context, commentId int64) error
+	// List likes for a comment
+	// (GET /v1/comments/{commentId}/likes)
+	ListCommentLikesV1(ctx echo.Context, commentId int64) error
+	// Like a comment
+	// (POST /v1/comments/{commentId}/likes)
+	CreateCommentLikeV1(ctx echo.Context, commentId int64) error
 	// List posts
 	// (GET /v1/posts)
 	ListPostsV1(ctx echo.Context) error
@@ -2782,6 +3618,15 @@ type ServerInterface interface {
 	// Update a specific comment by ID
 	// (PUT /v1/posts/{postId}/comments/{id})
 	UpdateCommentV1(ctx echo.Context, postId int64, id int64) error
+	// Unlike a post
+	// (DELETE /v1/posts/{postId}/likes)
+	DeletePostLikeV1(ctx echo.Context, postId int64) error
+	// List likes for a post
+	// (GET /v1/posts/{postId}/likes)
+	ListPostLikesV1(ctx echo.Context, postId int64) error
+	// Like a post
+	// (POST /v1/posts/{postId}/likes)
+	CreatePostLikeV1(ctx echo.Context, postId int64) error
 	// Get current user profile
 	// (GET /v1/users)
 	GetUserProfileV1(ctx echo.Context) error
@@ -2828,6 +3673,60 @@ func (w *ServerInterfaceWrapper) SignupUserV1(ctx echo.Context) error {
 
 	// Invoke the callback with all the unmarshaled arguments
 	err = w.Handler.SignupUserV1(ctx)
+	return err
+}
+
+// DeleteCommentLikeV1 converts echo context to params.
+func (w *ServerInterfaceWrapper) DeleteCommentLikeV1(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "commentId" -------------
+	var commentId int64
+
+	err = runtime.BindStyledParameterWithOptions("simple", "commentId", ctx.Param("commentId"), &commentId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter commentId: %s", err))
+	}
+
+	ctx.Set(BearerAuthScopes, []string{})
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.DeleteCommentLikeV1(ctx, commentId)
+	return err
+}
+
+// ListCommentLikesV1 converts echo context to params.
+func (w *ServerInterfaceWrapper) ListCommentLikesV1(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "commentId" -------------
+	var commentId int64
+
+	err = runtime.BindStyledParameterWithOptions("simple", "commentId", ctx.Param("commentId"), &commentId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter commentId: %s", err))
+	}
+
+	ctx.Set(BearerAuthScopes, []string{})
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.ListCommentLikesV1(ctx, commentId)
+	return err
+}
+
+// CreateCommentLikeV1 converts echo context to params.
+func (w *ServerInterfaceWrapper) CreateCommentLikeV1(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "commentId" -------------
+	var commentId int64
+
+	err = runtime.BindStyledParameterWithOptions("simple", "commentId", ctx.Param("commentId"), &commentId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter commentId: %s", err))
+	}
+
+	ctx.Set(BearerAuthScopes, []string{})
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.CreateCommentLikeV1(ctx, commentId)
 	return err
 }
 
@@ -3021,6 +3920,60 @@ func (w *ServerInterfaceWrapper) UpdateCommentV1(ctx echo.Context) error {
 	return err
 }
 
+// DeletePostLikeV1 converts echo context to params.
+func (w *ServerInterfaceWrapper) DeletePostLikeV1(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "postId" -------------
+	var postId int64
+
+	err = runtime.BindStyledParameterWithOptions("simple", "postId", ctx.Param("postId"), &postId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter postId: %s", err))
+	}
+
+	ctx.Set(BearerAuthScopes, []string{})
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.DeletePostLikeV1(ctx, postId)
+	return err
+}
+
+// ListPostLikesV1 converts echo context to params.
+func (w *ServerInterfaceWrapper) ListPostLikesV1(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "postId" -------------
+	var postId int64
+
+	err = runtime.BindStyledParameterWithOptions("simple", "postId", ctx.Param("postId"), &postId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter postId: %s", err))
+	}
+
+	ctx.Set(BearerAuthScopes, []string{})
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.ListPostLikesV1(ctx, postId)
+	return err
+}
+
+// CreatePostLikeV1 converts echo context to params.
+func (w *ServerInterfaceWrapper) CreatePostLikeV1(ctx echo.Context) error {
+	var err error
+	// ------------- Path parameter "postId" -------------
+	var postId int64
+
+	err = runtime.BindStyledParameterWithOptions("simple", "postId", ctx.Param("postId"), &postId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Invalid format for parameter postId: %s", err))
+	}
+
+	ctx.Set(BearerAuthScopes, []string{})
+
+	// Invoke the callback with all the unmarshaled arguments
+	err = w.Handler.CreatePostLikeV1(ctx, postId)
+	return err
+}
+
 // GetUserProfileV1 converts echo context to params.
 func (w *ServerInterfaceWrapper) GetUserProfileV1(ctx echo.Context) error {
 	var err error
@@ -3075,6 +4028,9 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.POST(baseURL+"/v1/auth/logout", wrapper.LogoutUserV1)
 	router.POST(baseURL+"/v1/auth/refresh", wrapper.RefreshAccessTokenV1)
 	router.POST(baseURL+"/v1/auth/signup", wrapper.SignupUserV1)
+	router.DELETE(baseURL+"/v1/comments/:commentId/likes", wrapper.DeleteCommentLikeV1)
+	router.GET(baseURL+"/v1/comments/:commentId/likes", wrapper.ListCommentLikesV1)
+	router.POST(baseURL+"/v1/comments/:commentId/likes", wrapper.CreateCommentLikeV1)
 	router.GET(baseURL+"/v1/posts", wrapper.ListPostsV1)
 	router.POST(baseURL+"/v1/posts", wrapper.CreatePostV1)
 	router.DELETE(baseURL+"/v1/posts/:id", wrapper.DeletePostV1)
@@ -3085,6 +4041,9 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 	router.DELETE(baseURL+"/v1/posts/:postId/comments/:id", wrapper.DeleteCommentV1)
 	router.GET(baseURL+"/v1/posts/:postId/comments/:id", wrapper.GetCommentByIdV1)
 	router.PUT(baseURL+"/v1/posts/:postId/comments/:id", wrapper.UpdateCommentV1)
+	router.DELETE(baseURL+"/v1/posts/:postId/likes", wrapper.DeletePostLikeV1)
+	router.GET(baseURL+"/v1/posts/:postId/likes", wrapper.ListPostLikesV1)
+	router.POST(baseURL+"/v1/posts/:postId/likes", wrapper.CreatePostLikeV1)
 	router.GET(baseURL+"/v1/users", wrapper.GetUserProfileV1)
 	router.PUT(baseURL+"/v1/users", wrapper.UpdateUserProfileV1)
 
@@ -3093,60 +4052,68 @@ func RegisterHandlersWithBaseURL(router EchoRouter, si ServerInterface, baseURL 
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xdbVfbOPb/Kvr7P+dsORuCU6C7zathSstJZigdCO3u9LA9wr5JRG3JI8mEdA7ffY8k",
-	"2/FjYgcHaDev2saydHWf709X7l+Ww/yAUaBSWP2/LOFMwcf6r0cBecs54+rvAWcBcElAP3GYC+pPF4TD",
-	"SSAJo1bfOqIIB4FHHKx+2BUBOGRMHARqEqTe6VodC+6wH3hg9a2PR78Njo9Gg7P3X96en5+dWx1LzgP1",
-	"REhO6MS671hjAp5bXGo0BZTMT2gQSqRHIg4eluAiyZCcQrT0C6bfw95OlgDwMfHKVvVBCDwp2yKahj6m",
-	"uxywi689QKnHiI0Xa2YXeqsWQmPGfSwREYjQW+wRt1tc+75jcfgzJBxcq//ZMHpBz1Uynl3fgCMVrbGU",
-	"zkEEjAooSksTJMrlxTmeI4dRiQkldIIYBcQ48hmPmWdWEopWIsHX8/zEYWz1rf/fW+jOXqQ4e4nW3CfE",
-	"6lUKe4vIKtvTG+b7QGWR5HMIOAi1HsLIMaMQowijgAmpaMwrKpWlEykFknAnUTQiFl40Z1Z8Jxyw1Cv8",
-	"X5m2OOoxuF9w2TrEByGxH6DZFGh6CTTDAkWvquWMdlh9y8USdiXxleCVnp1Rb271JQ+hZG1SYhyXlPwZ",
-	"AiIuUEnGBLjSvPzukuUIla8OqpciVMIEtDQVA76ULTg4jtmnhiA5JSLZ5TV4jE4EkmzNVcPAXZe7HhYS",
-	"Re+vz+JQAF+xbTUEzaYslueDmZ0zFeJaC/YvKOok+p1RwgzPSs1Lj42M7Bz+DEGUMPcYS4xiKpRDNUsg",
-	"jCjMHs/4BghPOICyPB/f/QZ0IqdW/9C2O5ZPaPzv3mpPaohZyY+L0HFAiLQ7zVJ/ITF1MXfRjOMgSFmX",
-	"MG+OQy/hjmaZig08mq7IJRdLvMqnxv4wvyn9bvWOPjCxrnhbkmg8zUKcw1BIJEBKFW3CAPlzdMJ2L5hD",
-	"sIew47CQypyse3b7wlasaUXS2uO1JGZFVH0Zn4DchMpykJzALfYeW2dPQLYrlbZ20lgslwL4B87GxINW",
-	"dqPDS2AmbG1Xisj6u/qNiFjbRKvq5pGGkqrIYdl4EZIaZqyJpq5IWJcyRymJaE93W2SLnq8pT4zOr80Q",
-	"NiG0ZuRRHNAK7qmXihs0RVoxyRXA/yaQfoqw63IQIhtpbjCFrsvg5+inrsP8dC4WV3+ZrCITZ/ZLssEA",
-	"CzFj3K2kKB6QJUbsO3xfBj8LMbO5myYjmXAZJf9cFfHizSSzLRFLlXLGT9L1oNLN4acRCgNG00paISzJ",
-	"vgItzjy8OHuPPsE1GqnnWuQ4lFNVnzg6XxYgBGE0J0GYD6fXJw45I8PB5bdB7z0ZiAE9P3TeDF4Nvgb/",
-	"+vhm+LoL8+E399OAnJHB3enNqf1+9O/9s+OvswGZkWv/nfzjQg++xScHk/OT1576HX96Zw9u2N370duX",
-	"pzenh6fHg/n49+7F2Pv1bnY+vDiFX3999/L30cF4FpzCcLz/6sPZ11fz4ccv2P1diNmhk5bgzUyuLOQN",
-	"YyqF0orj0DJ5YFTIqkhtg9fuYnm1rt0QMUWamAsJ/kbyy5EqPolQeeWYcNFe2a7pf4KaPd7i5kvnZIdP",
-	"WzevveGyovmhpfIFmdAwaBrKhH7r2ccybSBfKPahkiZjQ2pIrozDFBqvp/Rq+XJa84qrHTNoMVAfg9Di",
-	"eqRIbZSwfNsxKfEI9AJ7wRTT0AdOnJ2iErirORFgKYGr2f/zGe9+O9r9w959ffX3n1bGqJQ6pGWVor9T",
-	"L88wRtNKTDOW9KilzqX2CI3RMeNIEKYI7ojQ8EYKz2oQ5yKP1AQhE5IzOvHmm4fKMsxptRCM+PfIoIPZ",
-	"TzOgrETSa8Bly8RcTGsuo9GFtGZjONmCM+1Vta3IuBkcY7aRQmQq5fyOgOcKhD2PzeJgrl5W8sUZDGYb",
-	"2J8ysD/jaLpa+9rHA1uxqYYRUo1eXu1pEldVe80KMFMsZAuwhThf2i8Pdu3ebu9w1LP7+3bftv9Yu3RZ",
-	"35zZlNYx51Ytlk2p9eAyU3E3M2/P7q1VdGpfoKGIZVJNFYCxd0ggpRKh/mNkv+7bS4VKQ8/D1+o1Q9lK",
-	"IT/QaRX9UrNqO1HnfLVdsv1Xo97L/sHhg3S62m1Guw2NbsTjiortlu27rOhuUkjUL8bvO5YAJ+REzi+U",
-	"2zJO5BowB34UKncd/+tdzKDhp5HVMS1NaibzdLGHqZSBda8mJnTMSlD0D4Oky8ic78XWcsJQfGS56HjS",
-	"7TxEmpaRZMDRh4HVsW6BCzNpr2t3bSUQFgDFAbH61n7X7u7rokpO9ab2bnt7OJTTvcSOglKA7SgFoiZe",
-	"F1MXcZAhp+qn4aeRokv5XU3kwLX6BnNUYv/Ys4z8QMhfmDvPZa2pze3dCEYXDWI1cUSTamkWF3UuAiwd",
-	"DtodYU9YaWVSeqy1ywQ2zZiXtt0uifl4XEKqHpcKv110nuYu0tBuV0n0oEXqCm1dJZQNTBtZ1ACnwjV6",
-	"Ad1Jt4P070ZlTZvVTkRg70kINBGT8RTkct+xDh+ZXRfAb4FHbW1uqPxXHHS0cwl9H/O5kbjKXYw9KaPG",
-	"E6GcW8rcFGc/9qwr9WLaWlkoq831jQeYi/TRh5rGYewrAVFqpSyUKTMtGkJBU1koM6r6niW1pfEJ8Kx4",
-	"z0JZxny1i8bc5zDmIKbV7L8UILT3jkYay0Uvxpz5kRR2VH1PhAjjPhisWRmPJLG0dorSOjeTHukX9DlX",
-	"TakdpZeISAM3JUVvXipHpaLXzFUPE0K/mFkMkUiAfFKzZxz5RAgl6wzLn40GZnieV8RIoBkVaKCOBrlc",
-	"4gx04iMiPTOR27Q/FXXLAKobDdjZg46qiB3BsS5ITGqF617LBNaI14bQlPUgDhMiJHBwF7Fbo6nRqZNm",
-	"vkkzv5c4/vpRCbyMARXG4+rXUwXH3CCg4tkYtJE0j9LxrD0rBUJhkDK4etaszFdr8wRKz7h1j442ZN20",
-	"E3XciA4KmDR5rTdHMyKnKMATQpNSIRfs4x6iyqjRTtJb1apUwuCj7IbidqR8bHqKCJMTV4LOMx7frXgu",
-	"kSZiWnxIILqZQtbqf86WsJ+v7q8y2RCJsH6RUlYtQKOjnVrRRYPvce2a7byJcZ+sNi6aZDcWcIotyiWs",
-	"/KC7a81y3UcNN9VtwpVkRtEkm7iVxZtUR962bvy+zdt0ficngI1s+02+4b7cxNNhaO8v4t4ba/dAlh6B",
-	"qN+V3SfX44y2zVTFcD2v7QHMRCkPkLGzg+LK2gYMWTWKl+evVgf2/qPnWIgIRJnUAmKcfDPnzYap5lpV",
-	"pGaKvINHJU+LV2cxcnH3Elw0ONYUj1lInwOyoFi1pjkajS9YzvUcDY6rgu+KlDCqk1QKlZu2aHDR9Ydf",
-	"5gN3sylgxT2LKpl/r1nf1kBqpKMNTeQEZDP7CDDHPkjgQs9d7ILJXx1lyFgFIFMkEaob7+TU6ljm9Moc",
-	"MWUTwU6KXYUjy0Kb6FXHCsIyfFCfPkWp2qIh58GhdNFJs7FkutjGVBZhoh6ioGFSbW+AzLreJ+6Sqk6q",
-	"w/Sutkn1D5f9RP0t2+xntXNP2tXWcO2XUVNjfe+erUvUHwP3fi9q52wGmMUvmZtBqzKl9F3Ed4xX1Sjt",
-	"gmZVlx+X4mbJvrZJ1A+aRMUSXgfWy2l9DgGIFe4BqVSsddmV1GKum/p+ivk0R0mmZWy6hWyrBkSZ+Z5E",
-	"1gc1By4j3m0Yu8xdESjRmjfxZyCeDsGsaNVfRmxtHDN74XqbdW3d7WYx1uT2y/owa+GzNZUed3l6sw4Q",
-	"m6y9HhabdWqr4NjYmreI7IYR2YVSPpH9Mo5iYX8/+Ox6plyEaJPPjOXqlHz2tBZQm7ptV8BqowUeBa5t",
-	"HsO39cYPakDF0uNhEG5d+2lcfaQ+xZf9BOCm6ozOcqoWxc6zRpjXzhEyF3M3jDOvLnxiqNlpXgDZmyG2",
-	"gfOsjzlvC6D/Cdh5m+KtA0KvF5+KOHS9EBWVa8o51sGedaCKbtASajx6+oKXE3IOVHrzWs43+82/jeeD",
-	"S+4TV+l47uuB28SwjmNIrAq9EFMWeq7+Rc4D4uim3ikOAqCIjLNKsvO8jvnjbxY0ThMjG8hcN0/Zn2LR",
-	"Ij9cle60Z2yFO/UbznZKvh2xysrG5lMSSRh5irznAU6ifgL0Hd6c2Hayrjo8XsthRHG7vs8wsysCykrK",
-	"Y7gFjwU68JtRVscKuWf1rT0cEEstHk2af/Us9hYi/b9BmAtWWWm8+GhuZaPezqL4K94EKZaW1UuI8kmT",
-	"fdedy9y4KJ0rOYKvO1dy+lc6XTqNur+6/28AAAD//zGij8YQZAAA",
+	"H4sIAAAAAAAC/+xde1MbObb/Krp9p+omdY2xA8lu/NcwIaHMhMDwSHYnxaZE97Et6JZ6JDXGSfHdtyT1",
+	"+2F3m7YhjP8C7G7p6LzPT0fih2Uzz2cUqBTW4Icl7Al4WP+655P3nDOufvc584FLAvobmzmgfjogbE58",
+	"SRi1BtYeRdj3XWJj9cGW8MEmI2IjUIMg9U7X6lhwhz3fBWtgfd77ONzfOx8ef/r2/vT0+NTqWHLmq2+E",
+	"5ISOrfuONSLgOsWpzieA4vEJ9QOJ9JOIg4slOEgyJCcQTv2C6few+zJLAHiYuGWzeiAEHpctEU0CD9Mt",
+	"DtjBVy6g1NeIjZI5sxO9VxOhEeMelogIROgtdonTLc5937E4/BUQDo41+GoYndBzGT/Prq7BlorWSEqn",
+	"IHxGBRSlpQkS5fLiHM+QzajEhBI6RowCYhx5jEfMMzMJRSuR4OlxfuEwsgbW/24nurMdKs52rDX3MbF6",
+	"lsLaQrLK1vSOeR5QWST5FHwOQs2HMLLNU4hRhJHPhFQ05hWVytKBlAJJuJMofCISXjhmVnwHHLDUM/xP",
+	"mbbY6mtwvuGyeYgHQmLPR9MJ0PQUaIoFCl9V0xntsAaWgyVsSeIpwSs9O6buzBpIHkDJ3KTEOC4o+SsA",
+	"RBygkowIcKV5+dXF0xEq3+xWT0WohDFoaSoGfCubcLgfsU89guSEiHiVV+AyOhZIsiVnDXxnWe66WEgU",
+	"vr88iwMBfMGy1SNoOmGRPB/M7JypEMdK2J9Q1In1O6OEGZ6Vmpd+NjSyU/grAFHC3H0sMYqoUA7VTIEw",
+	"ojBdn/ENER5zAGV5Hr77CHQsJ9bgda/XsTxCo7/7iz2pIWYhP84C2wYh0u40S/2ZxNTB3EFTjn0/ZV3C",
+	"vDkK3Jg7mmUqNvBwuCKXHCzxIp8a+cP8ovS71Sv6SG6gleW45AbaWosiqulCTphYVk9bUs1omEQvDwMh",
+	"kQApVdgMfOTN0AHbOmM2wS7Cts0CKnNK2++1r7WKNa3IWLvulmSsiKov4wOQq7A9DpITuMXuuo3vAGS7",
+	"UmlrJY3FciGAn3A2Im47fkTHSd8M2NqqFJH1V6Xdz/y8UlH5f8I4vTi8IV3CmPiEjlWWPEJhRE59pf4S",
+	"Exa4DrpSTsMP3Cj5yDug6Pl5eUWSRCknowhy0AsvkAF23RmCO9sNBLkFNCVyElGTrXF2ev2S9IMGrqvK",
+	"l+qsq2FOq3mVS2gTV/mq92p3q7ez1e+d93uDnd6g1/tzTRmvIixDTL9XypH2st9askrEnxXXqyXF1SRH",
+	"NaQZ9dLRJceffkv5aipLTZSp3CRFFABEqxHAJQ2dZ0V9zEZJutuwGo6Dx4JieI6/ElL5rCU5o1gQ6aOo",
+	"XnittZjM7SELUQFItBcXW5SvcfENhWvi6dIMYWNCa2a1igPagF31UnGBBskq+kUTyfS3CDsOByGyrvka",
+	"U+g6DH4NP+razEu75ggiy5RemRx2p8RH+1iIKeNOJUXRA1lixI7Nd6T/qxDTHnfSZMQDzqPkn4uy6Wgx",
+	"8WhzxFKlnNE3adBM6ebhl3MU+IxmyqZyYUl2A7Q48uHZ8Sf0Ba7QufpeixwHcqJCmq1BBQFCEEZzEoTZ",
+	"4eTqwCbH5HB48X3Y/0SGYkhPX9vvhm+GN/6/Pr87fNuF2eF358uQHJPh3dH1Ue/T+b93jvdvpkMyJVfe",
+	"B/nnmX74Fh/sjk8P3rrqc/zlQ294ze4+nb9/dXR99Ppofzgb/dE9G7m/301PD8+O4PffP7z643x3NPWP",
+	"4HC08+bk+ObN7PDzN+z8IcT0tZ2W4PVULkQ7DWMqhdJOKatGemgJm1GR2gav3cX81FO7IWJyKjETEryV",
+	"1K7nEyIQEapmHREu2sM2Nf2PAGxGS1w9vhiv8HHBxaUXvCBTWwpPPCNjGvhNQ5nQbz35WKYN5BvFHlTS",
+	"ZGxIPZKDiDCFxvMpvZo/nda84mz7DFoM1PsgtLjWFKmNEpYvOyIlegK9wK4/wTTwgBP7ZVEJnMWc8LGU",
+	"wNXo//mKt77vbf3Z23p7+f+/LIxRKXVIyypFf6denmGMppWYZixprTDKhfYIjbcQjCNBmCK4CyuTFOjf",
+	"IM6FHqnJNoKQnNGxO1v9fkKGOa1WtCH/1gxomvU0A+FLJL0EFD9PzMW05iJ8upDWrAyDTzjTXlXbioyb",
+	"Qb1mGSm0t1LOHwi4jkDYddk0CubqZSVfnMF3N4H9MQP7E46mi7Wv/b2GVmyqYYRUTy/eaFhY7TUrwEyx",
+	"MB+I72/1X7cAxC9vzmxC65hzqxbLJtR6cJmpuNsCWh76Ag1FzJNqqgCMvEMMKZUI9R/nvbeD3lyh5ncS",
+	"Fgr5gU6r6JeaVduxOuer7ZLlvznvvxrsvn6QTle7zXC1gdGN6LmiYjtl6y4rupsUEvWL8fuOJcAOOJGz",
+	"M+W2jBO5AsyB7wXKXUd/fYgYdPjl3OqYvk81kvk2WcNESt+6VwMTOmIlKPrJMG7FNL0DkbUcMBS1QyRt",
+	"obrnkUjTVxc/sHcytDrWLXBhBu13e92eEgjzgWKfWANrp9vr7uiiSk70orZv+9s4kJPt2I78UoBtLwWi",
+	"xl4XUwdxkAGn6qPDL+eKLuV3NZFDxxoYzFGJ/XPfMvIDIX9jziyXtaYWt30tGE26aGviiCbV0iwu6lwI",
+	"WNoctDvCrrDSyqT0WGuXCWyaMa96vXZJzMfjElL1c6nw20Wnae4iDe12lUR3W6Su0PtaQtnQ9NqGXcIq",
+	"XKMX0B13O0h/blTW9KK+DAnsPwqBJmIynoJc7jvW6zWz6wz4LfCw99cJuN48NEFHO5fA8zCfGYmr3MXY",
+	"kzJqPBbKuaXMTXH2c9+6VC+mrZUFstpc37mAuUhvfahhbMZuiNnBLFgpC2TKTIuGUNBUFsiMqn5icW1p",
+	"fAI8Kd6zQJYxX62iMfc5jDiISTX7LwQI7b3DJ43lohcjzrxQCi9VfU+ECKIeO6xZGT1JImm9LErr1Ay6",
+	"p1/Q+1w1pbaXniIkDZyUFN1ZqRyVil4xR30ZE/rNjGKIRALko5o948gjQihZZ1j+ZDQww/O8IoYCzahA",
+	"A3U0yOUcZ6ATHxHqmYncprWyqFsGUF1pwM5udFRF7BCOdUBiUitc91smsEa8NoSmrAdxGBMhgYOTxG6N",
+	"poa7Tpr5Js38WeL427USeBEBKoxH1a+rCo6ZQUDFkzFoI2kepuNZe1YKhAI/ZXD1rDkEqMX2j/C3oXO/",
+	"rZuOjFG7IEubKTx2G8abbK9DugdThx6cnPdK4ftZD7Cvpwnh7Y/kBsqCy26Jl4nQdWp64xZGlUcJGDnu",
+	"x2A749F5skyWvbtW4iIWUibRiAVUk6Wll3ySRVEe3RiUskStcd1M5WwNvmZr5q+X95dpK7nQipIcQUvZ",
+	"iO7VM6bRscZQ2vChG9Z0VNMdbGxk2vNMy08NPU81TOrpKnOodkrAqg7EMh3NrShszsvb1MZ8FpnP49tH",
+	"KLpU82gjE1Fak1HrBabiY449kMCFHrq4FVjoitdtmlS3HMiJ1bEMbmfF8aeQeHVSrCpgtoU+mctOrZw0",
+	"OSWQt9vY3xUjW9GkM0fQqkJXewZTfT5sjnKWBceyTNGwJJ0pbix9gaWvO1eNqIgyVCPaq1kCujOOmJwA",
+	"V7nPyCWhKB/VI5nDactF7I814nWYyiqr1wZXO3rrNzrIZ9JAtO4sPJGDx4TGqHcxhut2+NUH79Ku+7nB",
+	"Wy/opw3eTyVsai4uEzaNBiY6qgUYB8oaQUn3kTQPP2qelWEnxZO8Jaw80YdQk2NJ60NOqk/TVpIZhrvF",
+	"ATF1uGSzBfJzm3ccg0z3WSPbfpc/l15u4ukwtP2DOPfzEBQDeYh0+mm0bUqTgF7HA5iBUh5gEWiibcCQ",
+	"9UwQk521w4WICJ0IKgExTr6b1knDVHONSqhm689TtXh1FiOTu5bAUWXYEypSYxBnCXM0Gl+wnKsZGu5X",
+	"Bd8FKWEI+asUKjds0eDCWwJ+mw2d1aaAFdcRVMl8A9k8JwPJpaMNTeQAZDP7aIDimKuiGDJWAcgUSSWA",
+	"DmkDyQnKtrp1I5VIH4UvsdzmoTRpCl9ZMl3syC+LMGE7vN8wqe6tgMy63idq+K9OqoP0qjZJ9bPLfsJW",
+	"7U32s9i5xycvlnDtF+H5nPrePVuXqB9D5z7e+G0EmEUv5Xe8yjOl9P0gHxivqlHaBc2qLiSZi5vF69ok",
+	"Uc80iYokvAysl9P6HAIQKdwDUqlI67IzqckcJ3VfqrmKsyTTMja9nn2zzP2RWR+09L7ZirHL3GnXOdsq",
+	"j4hgVpw6nUdsbRwzewnSJuvauNvVYqzxRv/yMGvhmtpKjzs/vVkGiI3nXg6LzTq1uj1sG0R2xYhsopSP",
+	"ZL+Mo0jYPw8+u5wpFyHa+EbMXJ2Sz56WAmorG+6SG2rXAtc2j+GbeuOZGlCx9HgYhFvXfhpXH5nbatNX",
+	"/q+qzujUahJ86gjz0jlC5o6ZFePMiwufCGq2mxdAvdUQ28B51secNwXQ3wJ23qR4y4DQy8WnIg5dL0SV",
+	"l2srOnFUjksnLTMNzhqZXa7NQaMH2cff7JRRDrdo8YhR9YZLpNabw0XPzGSe38mieebRsI55AhsjJQeK",
+	"HtDO/cSOEp0wsTlHtCqjXvchIk3C3+0EUbWzCTNStfY63RDa5YTXExJq3Ef69iw74ByodGe1LD77z5pW",
+	"jlDOuayxqurK/dunTdSuU6omae2L8N9KqU/kzCe2PmY2wb4PFJFRVklePq3G0+hC2MbAZWgDmbs8U8an",
+	"WJRE+kUAXHvGVriwdMX4W8nFvIusbGTu6Y2BjcdA4h7gJOpDcj/htTSbs1WL2hmXchghklTfZ5jRFQFl",
+	"xcE+3ILLfA1FmaesjhVw1xpY29gnlpo8HDT/6nHkLUT6/5Gb26uy0njx2Vx5ifovk2qjeM1OcbOjegpR",
+	"Pmi87rpjmTPApWPFTaF1x4r70UqHSwN7dUc09R+jIZmYOgsmiRO1+8v7/wYAAP//YE4bbvR+AAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,0 +1,44 @@
+# Active Context
+
+## Current Work Focus
+
+- Updating the Memory Bank with initial project context.
+- Preparing to discuss and plan the implementation of a new "likes" endpoint.
+
+## Recent Changes
+
+- Initialized the Memory Bank with placeholder files.
+- Updated `projectbrief.md` and `productContext.md` with information from `README.md` and user input.
+
+## Next Steps
+
+- Complete updates for `systemPatterns.md`, `techContext.md`, and `progress.md`.
+- Discuss the requirements and design for the new "likes" endpoint.
+- Define the OpenAPI specification for the "likes" endpoint.
+- Implement the backend logic for "likes".
+- Implement the frontend UI and logic for "likes".
+
+## Active Decisions and Considerations
+
+- How to structure the "likes" feature:
+    - Can users like posts, comments, or both?
+    - What data needs to be stored for a "like" (e.g., user ID, liked item ID, timestamp)?
+    - How will "like" counts be efficiently retrieved and displayed?
+- Adhering to existing OpenAPI conventions when defining the new endpoint.
+- The need for a strategy to manage and version OpenAPI bundled specifications over time (a future task).
+
+## Important Patterns and Preferences
+
+- Use of OpenAPI as the single source of truth for API contracts.
+- Code generation for backend (Go) and frontend (TypeScript) types from OpenAPI.
+- Facade pattern to decouple application code from generated types.
+- Consistent API response structure (`data` for success, `errors` for failure).
+- API versioning (currently at v1).
+- Use of partial OpenAPI files, bundled using `@redocly/cli`.
+
+## Learnings and Project Insights
+
+- The project has a well-defined structure for API development using OpenAPI.
+- Clear separation of concerns between backend and frontend.
+- Established processes for dependency management, testing, and running the application (via `Makefile`).
+- The `README.md` provides a good overview of the project setup and development workflows.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -27,6 +27,267 @@
 - The implementation of backend/frontend logic for "likes" is out of scope for the current task.
 - The need for a strategy to manage and version OpenAPI bundled specifications over time remains a future task.
 
+### Proposed OpenAPI Specification for "Likes" (for discussion)
+
+**1. New File: `openapi/v1/schemas/like.yaml`**
+```yaml
+# openapi/v1/schemas/like.yaml
+components:
+  schemas:
+    Like:
+      type: object
+      description: Represents a user's like on a post or comment. One of post_id or comment_id should be populated.
+      properties:
+        id:
+          type: string
+          description: Unique identifier for the like.
+          readOnly: true
+          example: "lk_clxkz2kv0000008jy1g7g3h7n"
+        user_id:
+          type: string # Corresponds to User ID. If User.id is int64, this should be int64 too.
+          description: ID of the user who liked the content.
+          readOnly: true # Set by the backend based on authenticated user.
+          example: "usr_clxkyv02o000008jye1g2f3h5" # Example if User ID is string
+          # if User ID is int64:
+          # type: integer
+          # format: int64
+          # example: 101
+        post_id:
+          type: string # Corresponds to Post ID. If Post.id is int64, this should be int64.
+          description: ID of the post being liked (mutually exclusive with comment_id).
+          nullable: true
+          example: "post_clxkz0q9k000008jya1b7g2e3" # Example if Post ID is string
+          # if Post ID is int64:
+          # type: integer
+          # format: int64
+          # example: 201
+        comment_id:
+          type: string # Corresponds to Comment ID. If Comment.id is int64, this should be int64.
+          description: ID of the comment being liked (mutually exclusive with post_id).
+          nullable: true
+          example: "cmt_clxkz1b2a000008jyf4g6h7i8" # Example if Comment ID is string
+          # if Comment ID is int64:
+          # type: integer
+          # format: int64
+          # example: 301
+        created_at:
+          type: string
+          format: date-time
+          description: Timestamp when the like was created.
+          readOnly: true
+          example: '2024-03-10T10:30:00Z'
+      required:
+        - id
+        - user_id
+        - created_at
+
+    CreateLikeSuccessResponse:
+      type: object
+      description: Standard wrapper for the successful like creation response.
+      properties:
+        data:
+          $ref: '#/components/schemas/Like'
+      required:
+        - data
+
+    ListLikesSuccessResponse:
+      type: object
+      description: Standard wrapper for listing likes.
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Like'
+      required:
+        - data
+```
+
+**2. New File: `openapi/v1/paths/like.yaml`**
+```yaml
+# openapi/v1/paths/like.yaml
+paths:
+  /v1/posts/{postId}/likes:
+    parameters:
+      - name: postId
+        in: path
+        required: true
+        description: The ID of the post.
+        schema:
+          type: string # Should match Post.id type (string or integer)
+    get:
+      tags:
+        - Likes V1
+      summary: List likes for a post
+      description: Retrieves a list of likes for a specific post.
+      operationId: listPostLikesV1
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: A list of likes retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListLikesSuccessResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - Likes V1
+      summary: Like a post
+      description: Creates a new like on a specific post for the authenticated user.
+      operationId: createPostLikeV1
+      security:
+        - bearerAuth: []
+      responses:
+        '201':
+          description: Post liked successfully. Returns the created like object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateLikeSuccessResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '409':
+          $ref: '#/components/responses/ConflictError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - Likes V1
+      summary: Unlike a post
+      description: Removes the authenticated user's like from a specific post.
+      operationId: deletePostLikeV1
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Post unliked successfully. No content returned.
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /v1/comments/{commentId}/likes:
+    parameters:
+      - name: commentId
+        in: path
+        required: true
+        description: The ID of the comment.
+        schema:
+          type: string # Should match Comment.id type (string or integer)
+    get:
+      tags:
+        - Likes V1
+      summary: List likes for a comment
+      description: Retrieves a list of likes for a specific comment.
+      operationId: listCommentLikesV1
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: A list of likes retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListLikesSuccessResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags:
+        - Likes V1
+      summary: Like a comment
+      description: Creates a new like on a specific comment for the authenticated user.
+      operationId: createCommentLikeV1
+      security:
+        - bearerAuth: []
+      responses:
+        '201':
+          description: Comment liked successfully. Returns the created like object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateLikeSuccessResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '409':
+          $ref: '#/components/responses/ConflictError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    delete:
+      tags:
+        - Likes V1
+      summary: Unlike a comment
+      description: Removes the authenticated user's like from a specific comment.
+      operationId: deleteCommentLikeV1
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Comment unliked successfully. No content returned.
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+```
+
+**3. Updates to `openapi/openapi.yaml` (relevant parts)**
+```yaml
+# openapi/openapi.yaml
+# ...
+tags:
+  # ... existing tags ...
+  - name: Likes V1 # New Tag
+    description: Operations related to likes on posts and comments (Version 1)
+
+paths:
+  # ... existing path references ...
+  # New Path References for Likes
+  /v1/posts/{postId}/likes:
+    $ref: './v1/paths/like.yaml#/paths/~1v1~1posts~1{postId}~1likes'
+  /v1/comments/{commentId}/likes:
+    $ref: './v1/paths/like.yaml#/paths/~1v1~1comments~1{commentId}~1likes'
+
+components:
+  schemas:
+    # ... existing schema references ...
+    # New Schema References for Likes
+    Like:
+      $ref: './v1/schemas/like.yaml#/components/schemas/Like'
+    CreateLikeSuccessResponse:
+      $ref: './v1/schemas/like.yaml#/components/schemas/CreateLikeSuccessResponse'
+    ListLikesSuccessResponse:
+      $ref: './v1/schemas/like.yaml#/components/schemas/ListLikesSuccessResponse'
+  
+  # responses: # Common responses should be defined centrally
+  #   UnauthorizedError: ...
+  #   NotFoundError: ...
+  #   ConflictError: ...
+  #   InternalServerError: ...
+# ...
+```
+
+**Discussion Points for this Proposal:**
+1.  **ID Types:** Confirm if `Like` related IDs (`id`, `user_id`, `post_id`, `comment_id`) should be `string` (as per Go struct) or `integer` (like other entities).
+2.  **Listing Likes Content:** Is an array of full `Like` objects suitable for `GET` requests, or would a list of user IDs/count be preferred in some cases?
+3.  **Common Error Responses:** Ensure `#/components/responses/*` refs point to correctly defined shared responses.
+
 ## Important Patterns and Preferences
 
 - Use of OpenAPI as the single source of truth for API contracts.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -276,17 +276,18 @@ components:
       $ref: './v1/schemas/like.yaml#/components/schemas/ListLikesSuccessResponse'
   
   # responses: # Common responses should be defined centrally
-  #   UnauthorizedError: ...
-  #   NotFoundError: ...
-  #   ConflictError: ...
-  #   InternalServerError: ...
+  # responses:
+  #   Common response components like UnauthorizedError, NotFoundError etc. are not explicitly defined here.
+  #   Instead, individual operations directly reference #/components/schemas/ApiErrorResponse for their error states,
+  #   with the expectation that the backend will populate the 'code' and 'message' fields appropriately for each error type.
+  #   If more specific, reusable error response components are desired later, they can be added here or in shared/schemas/common.yaml.
 # ...
 ```
 
-**Discussion Points for this Proposal:**
-1.  **ID Types:** Confirm if `Like` related IDs (`id`, `user_id`, `post_id`, `comment_id`) should be `string` (as per Go struct) or `integer` (like other entities).
-2.  **Listing Likes Content:** Is an array of full `Like` objects suitable for `GET` requests, or would a list of user IDs/count be preferred in some cases?
-3.  **Common Error Responses:** Ensure `#/components/responses/*` refs point to correctly defined shared responses.
+**Summary of Changes Based on Feedback:**
+1.  **ID Types:** All `Like` related IDs (`id`, `user_id`, `post_id`, `comment_id`) and path parameters (`postId`, `commentId`) are now `type: integer`, `format: int64`. Examples updated.
+2.  **Listing Likes Content:** Remains as an array of full `Like` objects.
+3.  **Common Error Responses:** Error responses now directly reference `#/components/schemas/ApiErrorResponse`. Descriptions have been added to each error status code for clarity.
 
 ## Important Patterns and Preferences
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -2,23 +2,24 @@
 
 ## Current Work Focus
 
-- Troubleshooting and correcting the OpenAPI specification for the new "likes" endpoint to ensure it appears in Swagger UI.
+- Finalizing Memory Bank updates after successfully defining the OpenAPI specification for the "likes" endpoint.
 
 ## Recent Changes
 
 - Initialized the Memory Bank with placeholder files.
 - Updated `projectbrief.md`, `productContext.md`, `systemPatterns.md`, and `techContext.md` with information from `README.md` and user input.
-- Created `openapi/v1/schemas/like.yaml` and `openapi/v1/paths/like.yaml`.
-- Attempted to update `openapi/openapi.yaml` and ran `make generate-types`.
-- Identified that "likes" paths are not appearing in Swagger UI, likely due to an issue in `openapi/openapi.yaml`'s references.
-- Updated the proposed OpenAPI spec in this file based on feedback (integer IDs, direct `ApiErrorResponse` refs).
+- Iteratively defined and corrected the OpenAPI specification for the "likes" feature:
+    - Created `openapi/v1/schemas/like.yaml` (with integer IDs).
+    - Created `openapi/v1/paths/like.yaml` (with relative path refs for schemas).
+    - Updated `openapi/openapi.yaml` with the "Likes V1" tag and correct path/schema references.
+- Successfully ran `make generate-types`, bundling the spec and generating types.
+- Confirmed (by user) that the new "likes" endpoints are correctly represented in Swagger UI.
+- Updated Memory Bank (`activeContext.md`, `progress.md`) to reflect troubleshooting steps and then successful completion.
 
 ## Next Steps
 
-1.  **Update `memory-bank/activeContext.md` and `memory-bank/progress.md` to reflect the current troubleshooting status (this step).**
-2.  Correctly update `openapi/openapi.yaml` to include the "Likes V1" tag and the path references for `/v1/posts/{postId}/likes` and `/v1/comments/{commentId}/likes`.
-3.  Run `make generate-types` again.
-4.  Confirm the new "likes" endpoint is correctly represented in the Swagger UI.
+1.  **Finalize Memory Bank updates to reflect task completion (this step).**
+2.  (No further technical steps for this task)
 
 ## Active Decisions and Considerations
 
@@ -29,7 +30,7 @@
 - The implementation of backend/frontend logic for "likes" is out of scope for the current task.
 - The need for a strategy to manage and version OpenAPI bundled specifications over time remains a future task.
 
-### Proposed OpenAPI Specification for "Likes" (for discussion)
+### Finalized OpenAPI Specification for "Likes" (as implemented)
 
 **1. New File: `openapi/v1/schemas/like.yaml`**
 ```yaml
@@ -41,37 +42,29 @@ components:
       description: Represents a user's like on a post or comment. One of post_id or comment_id should be populated.
       properties:
         id:
-          type: string
+          type: integer
+          format: int64
           description: Unique identifier for the like.
           readOnly: true
-          example: "lk_clxkz2kv0000008jy1g7g3h7n"
+          example: 1001
         user_id:
-          type: string # Corresponds to User ID. If User.id is int64, this should be int64 too.
+          type: integer
+          format: int64
           description: ID of the user who liked the content.
           readOnly: true # Set by the backend based on authenticated user.
-          example: "usr_clxkyv02o000008jye1g2f3h5" # Example if User ID is string
-          # if User ID is int64:
-          # type: integer
-          # format: int64
-          # example: 101
+          example: 101
         post_id:
-          type: string # Corresponds to Post ID. If Post.id is int64, this should be int64.
+          type: integer
+          format: int64
           description: ID of the post being liked (mutually exclusive with comment_id).
           nullable: true
-          example: "post_clxkz0q9k000008jya1b7g2e3" # Example if Post ID is string
-          # if Post ID is int64:
-          # type: integer
-          # format: int64
-          # example: 201
+          example: 201
         comment_id:
-          type: string # Corresponds to Comment ID. If Comment.id is int64, this should be int64.
+          type: integer
+          format: int64
           description: ID of the comment being liked (mutually exclusive with post_id).
           nullable: true
-          example: "cmt_clxkz1b2a000008jyf4g6h7i8" # Example if Comment ID is string
-          # if Comment ID is int64:
-          # type: integer
-          # format: int64
-          # example: 301
+          example: 301
         created_at:
           type: string
           format: date-time
@@ -115,7 +108,8 @@ paths:
         required: true
         description: The ID of the post.
         schema:
-          type: string # Should match Post.id type (string or integer)
+          type: integer
+          format: int64
     get:
       tags:
         - Likes V1
@@ -130,13 +124,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListLikesSuccessResponse'
+                $ref: '../schemas/like.yaml#/components/schemas/ListLikesSuccessResponse'
         '401':
-          $ref: '#/components/responses/UnauthorizedError'
+          description: Authentication required or invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
         '404':
-          $ref: '#/components/responses/NotFoundError'
+          description: Post not found.
+          content:
+            application/json:
+              schema:
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          description: Server error retrieving likes.
+          content:
+            application/json:
+              schema:
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
     post:
       tags:
         - Likes V1
@@ -151,15 +157,31 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreateLikeSuccessResponse'
+                $ref: '../schemas/like.yaml#/components/schemas/CreateLikeSuccessResponse'
         '401':
-          $ref: '#/components/responses/UnauthorizedError'
+          description: Authentication required or invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
         '404':
-          $ref: '#/components/responses/NotFoundError'
+          description: Post not found.
+          content:
+            application/json:
+              schema:
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
         '409':
-          $ref: '#/components/responses/ConflictError'
+          description: Post already liked by the user or other conflict.
+          content:
+            application/json:
+              schema:
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          description: Server error creating like.
+          content:
+            application/json:
+              schema:
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
     delete:
       tags:
         - Likes V1
@@ -172,11 +194,23 @@ paths:
         '204':
           description: Post unliked successfully. No content returned.
         '401':
-          $ref: '#/components/responses/UnauthorizedError'
+          description: Authentication required or invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
         '404':
-          $ref: '#/components/responses/NotFoundError'
+          description: Post not found or like not found for the user.
+          content:
+            application/json:
+              schema:
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          description: Server error deleting like.
+          content:
+            application/json:
+              schema:
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
 
   /v1/comments/{commentId}/likes:
     parameters:
@@ -185,7 +219,8 @@ paths:
         required: true
         description: The ID of the comment.
         schema:
-          type: string # Should match Comment.id type (string or integer)
+          type: integer
+          format: int64
     get:
       tags:
         - Likes V1
@@ -200,13 +235,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListLikesSuccessResponse'
+                $ref: '../schemas/like.yaml#/components/schemas/ListLikesSuccessResponse'
         '401':
-          $ref: '#/components/responses/UnauthorizedError'
+          description: Authentication required or invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
         '404':
-          $ref: '#/components/responses/NotFoundError'
+          description: Comment not found.
+          content:
+            application/json:
+              schema:
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          description: Server error retrieving likes.
+          content:
+            application/json:
+              schema:
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
     post:
       tags:
         - Likes V1
@@ -221,15 +268,31 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreateLikeSuccessResponse'
+                $ref: '../schemas/like.yaml#/components/schemas/CreateLikeSuccessResponse'
         '401':
-          $ref: '#/components/responses/UnauthorizedError'
+          description: Authentication required or invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
         '404':
-          $ref: '#/components/responses/NotFoundError'
+          description: Comment not found.
+          content:
+            application/json:
+              schema:
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
         '409':
-          $ref: '#/components/responses/ConflictError'
+          description: Comment already liked by the user or other conflict.
+          content:
+            application/json:
+              schema:
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          description: Server error creating like.
+          content:
+            application/json:
+              schema:
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
     delete:
       tags:
         - Likes V1
@@ -242,11 +305,23 @@ paths:
         '204':
           description: Comment unliked successfully. No content returned.
         '401':
-          $ref: '#/components/responses/UnauthorizedError'
+          description: Authentication required or invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
         '404':
-          $ref: '#/components/responses/NotFoundError'
+          description: Comment not found or like not found for the user.
+          content:
+            application/json:
+              schema:
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
         '500':
-          $ref: '#/components/responses/InternalServerError'
+          description: Server error deleting like.
+          content:
+            application/json:
+              schema:
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
 ```
 
 **3. Updates to `openapi/openapi.yaml` (relevant parts)**

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -2,30 +2,30 @@
 
 ## Current Work Focus
 
-- Updating the Memory Bank with initial project context.
-- Preparing to discuss and plan the implementation of a new "likes" endpoint.
+- Refining project scope in Memory Bank and planning the OpenAPI specification for a new 'likes' endpoint.
 
 ## Recent Changes
 
 - Initialized the Memory Bank with placeholder files.
-- Updated `projectbrief.md` and `productContext.md` with information from `README.md` and user input.
+- Updated `projectbrief.md`, `productContext.md`, `systemPatterns.md`, and `techContext.md` with information from `README.md` and user input.
 
 ## Next Steps
 
-- Complete updates for `systemPatterns.md`, `techContext.md`, and `progress.md`.
-- Discuss the requirements and design for the new "likes" endpoint.
-- Define the OpenAPI specification for the "likes" endpoint.
-- Implement the backend logic for "likes".
-- Implement the frontend UI and logic for "likes".
+1.  Finalize scope adjustments in Memory Bank files (`activeContext.md`, `projectbrief.md`, `progress.md`).
+2.  Discuss and define the requirements and design for the new "likes" endpoint (e.g., what can be liked, data structure for a like).
+3.  Create/update the necessary OpenAPI partial files (e.g., new schemas in `openapi/shared/schemas/` or `openapi/v1/schemas/`, new paths in `openapi/v1/paths/`).
+4.  Update `openapi/openapi.yaml` to reference the new "likes" paths and schemas.
+5.  Run `make generate-types` (or at least the `redocly bundle` part) to create an updated `openapi/openapi-bundled.yaml`.
+6.  Confirm the new "likes" endpoint is correctly represented in the Swagger UI.
 
 ## Active Decisions and Considerations
 
-- How to structure the "likes" feature:
-    - Can users like posts, comments, or both?
-    - What data needs to be stored for a "like" (e.g., user ID, liked item ID, timestamp)?
-    - How will "like" counts be efficiently retrieved and displayed?
-- Adhering to existing OpenAPI conventions when defining the new endpoint.
-- The need for a strategy to manage and version OpenAPI bundled specifications over time (a future task).
+- How to structure the "likes" feature within the OpenAPI specification:
+    - Can users like posts, comments, or both? This will determine the path structure and request/response schemas.
+    - What data needs to be represented in the "like" schema (e.g., user ID, liked item ID, timestamp)?
+- Adhering to existing OpenAPI conventions (e.g., response wrappers, error handling, naming) when defining the new endpoint.
+- The implementation of backend/frontend logic for "likes" is out of scope for the current task.
+- The need for a strategy to manage and version OpenAPI bundled specifications over time remains a future task.
 
 ## Important Patterns and Preferences
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -2,21 +2,23 @@
 
 ## Current Work Focus
 
-- Refining project scope in Memory Bank and planning the OpenAPI specification for a new 'likes' endpoint.
+- Troubleshooting and correcting the OpenAPI specification for the new "likes" endpoint to ensure it appears in Swagger UI.
 
 ## Recent Changes
 
 - Initialized the Memory Bank with placeholder files.
 - Updated `projectbrief.md`, `productContext.md`, `systemPatterns.md`, and `techContext.md` with information from `README.md` and user input.
+- Created `openapi/v1/schemas/like.yaml` and `openapi/v1/paths/like.yaml`.
+- Attempted to update `openapi/openapi.yaml` and ran `make generate-types`.
+- Identified that "likes" paths are not appearing in Swagger UI, likely due to an issue in `openapi/openapi.yaml`'s references.
+- Updated the proposed OpenAPI spec in this file based on feedback (integer IDs, direct `ApiErrorResponse` refs).
 
 ## Next Steps
 
-1.  Finalize scope adjustments in Memory Bank files (`activeContext.md`, `projectbrief.md`, `progress.md`).
-2.  Discuss and define the requirements and design for the new "likes" endpoint (e.g., what can be liked, data structure for a like).
-3.  Create/update the necessary OpenAPI partial files (e.g., new schemas in `openapi/shared/schemas/` or `openapi/v1/schemas/`, new paths in `openapi/v1/paths/`).
-4.  Update `openapi/openapi.yaml` to reference the new "likes" paths and schemas.
-5.  Run `make generate-types` (or at least the `redocly bundle` part) to create an updated `openapi/openapi-bundled.yaml`.
-6.  Confirm the new "likes" endpoint is correctly represented in the Swagger UI.
+1.  **Update `memory-bank/activeContext.md` and `memory-bank/progress.md` to reflect the current troubleshooting status (this step).**
+2.  Correctly update `openapi/openapi.yaml` to include the "Likes V1" tag and the path references for `/v1/posts/{postId}/likes` and `/v1/comments/{commentId}/likes`.
+3.  Run `make generate-types` again.
+4.  Confirm the new "likes" endpoint is correctly represented in the Swagger UI.
 
 ## Active Decisions and Considerations
 

--- a/memory-bank/productContext.md
+++ b/memory-bank/productContext.md
@@ -1,0 +1,23 @@
+# Product Context
+
+## Problem Solved
+
+- Provides a platform for social interaction, allowing users to share content (posts) and engage in discussions (comments).
+- Addresses the need for a structured and maintainable API by using OpenAPI specifications, ensuring consistency between backend and frontend.
+
+## How it Works
+
+- The system consists of a Go backend and a React frontend.
+- The backend exposes a RESTful API defined by an OpenAPI specification.
+- Users can create accounts, log in, create posts, and comment on posts.
+- The frontend interacts with the backend API to display information and allow user actions.
+- API responses follow a consistent structure: `data` key for success, `errors` key for failures.
+- Code generation tools (`oapi-codegen` for Go, `openapi-typescript` for TS) are used to create types from the OpenAPI spec.
+- Facade patterns are used in both backend and frontend to decouple application code from generated types.
+
+## User Experience Goals
+
+- Provide an intuitive and responsive interface for social interactions.
+- Ensure clear feedback to users for actions (e.g., successful post creation, login errors).
+- Maintain API stability for current and future client applications through versioning.
+- Offer interactive API documentation via Swagger UI for developers.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -15,8 +15,11 @@
 
 ## What's Left to Build
 
-- **New Features:**
-    - "Likes" functionality for posts and/or comments. This is the immediate next feature.
+- **Immediate Next Task:**
+    - Define OpenAPI specification for "likes" functionality (for posts and/or comments).
+- **Future Features (Post-Spec Definition):**
+    - Implement backend logic for "likes".
+    - Implement frontend UI and logic for "likes".
 - **Technical Improvements/Future Considerations:**
     - Strategy for producing and persisting different OpenAPI bundle snapshots over time.
     - Potentially more comprehensive testing.
@@ -25,8 +28,8 @@
 
 ## Current Status
 
-- The Memory Bank has been initialized and populated with initial project context based on `README.md` and user input.
-- The next immediate task is to discuss, plan, and implement the "likes" feature.
+- The Memory Bank has been initialized and updated to reflect the current project understanding and narrowed scope for the "likes" feature.
+- The next immediate task is to discuss, plan, and define the OpenAPI specification for the "likes" feature. Full implementation is deferred.
 
 ## Known Issues
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -16,7 +16,9 @@
 ## What's Left to Build
 
 - **Immediate Next Task:**
-    - Define OpenAPI specification for "likes" functionality (for posts and/or comments).
+    - Correctly update `openapi/openapi.yaml` to include the "Likes V1" tag and path references.
+    - Run `make generate-types` to regenerate `openapi-bundled.yaml`.
+    - Verify the "likes" endpoints appear correctly in Swagger UI.
 - **Future Features (Post-Spec Definition):**
     - Implement backend logic for "likes".
     - Implement frontend UI and logic for "likes".
@@ -28,12 +30,15 @@
 
 ## Current Status
 
-- The Memory Bank has been initialized and updated to reflect the current project understanding and narrowed scope for the "likes" feature.
-- The next immediate task is to discuss, plan, and define the OpenAPI specification for the "likes" feature. Full implementation is deferred.
+- Partial OpenAPI files for "likes" (`like.yaml` for schemas and paths) have been created.
+- An attempt to update `openapi/openapi.yaml` and generate the bundled spec was made.
+- Currently troubleshooting why the "likes" endpoints are not visible in Swagger UI, suspecting an issue with how `openapi/openapi.yaml` references the new partials.
+- The Memory Bank is being updated to reflect this troubleshooting phase.
 
 ## Known Issues
 
-- No specific issues identified from the provided context, apart from the "missing feature" of OpenAPI bundle snapshotting.
+- "Likes" endpoints not appearing in Swagger UI after initial spec file creation and bundling attempt.
+- The "missing feature" of OpenAPI bundle snapshotting (longer-term).
 
 ## Evolution of Project Decisions
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -15,13 +15,9 @@
 
 ## What's Left to Build
 
-- **Immediate Next Task:**
-    - Correctly update `openapi/openapi.yaml` to include the "Likes V1" tag and path references.
-    - Run `make generate-types` to regenerate `openapi-bundled.yaml`.
-    - Verify the "likes" endpoints appear correctly in Swagger UI.
 - **Future Features (Post-Spec Definition):**
-    - Implement backend logic for "likes".
-    - Implement frontend UI and logic for "likes".
+    - Implement backend logic for "likes" (database tables, repositories, services, handlers).
+    - Implement frontend UI and logic for "likes" (components, API calls, state management).
 - **Technical Improvements/Future Considerations:**
     - Strategy for producing and persisting different OpenAPI bundle snapshots over time.
     - Potentially more comprehensive testing.
@@ -30,14 +26,16 @@
 
 ## Current Status
 
-- Partial OpenAPI files for "likes" (`like.yaml` for schemas and paths) have been created.
-- An attempt to update `openapi/openapi.yaml` and generate the bundled spec was made.
-- Currently troubleshooting why the "likes" endpoints are not visible in Swagger UI, suspecting an issue with how `openapi/openapi.yaml` references the new partials.
-- The Memory Bank is being updated to reflect this troubleshooting phase.
+- The OpenAPI specification for the "likes" feature has been successfully defined and verified in Swagger UI.
+    - `openapi/v1/schemas/like.yaml` created.
+    - `openapi/v1/paths/like.yaml` created and corrected.
+    - `openapi/openapi.yaml` updated with new tags and references.
+    - `make generate-types` successfully bundled the spec and generated types.
+- The Memory Bank (`activeContext.md`, `progress.md`) has been updated to reflect the completion of this task.
+- The next steps involve the actual implementation of the "likes" feature in the backend and frontend, which is out of scope for the current task.
 
 ## Known Issues
 
-- "Likes" endpoints not appearing in Swagger UI after initial spec file creation and bundling attempt.
 - The "missing feature" of OpenAPI bundle snapshotting (longer-term).
 
 ## Evolution of Project Decisions

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,0 +1,41 @@
+# Progress
+
+## What Works
+
+- Core application structure (Go backend, React frontend).
+- User authentication (signup, login, logout, token refresh).
+- Post creation, retrieval, updating, and deletion.
+- Comment creation, retrieval, updating, and deletion on posts.
+- Database setup with PostgreSQL and migrations using golang-migrate.
+- API definition using OpenAPI, with code generation for Go and TypeScript types.
+- Development environment setup with Docker, Makefiles for common tasks.
+- Frontend setup with Vite, TypeScript, Tailwind, Zustand, React Query.
+- Basic testing setup for backend and frontend.
+- Interactive API documentation via Swagger UI.
+
+## What's Left to Build
+
+- **New Features:**
+    - "Likes" functionality for posts and/or comments. This is the immediate next feature.
+- **Technical Improvements/Future Considerations:**
+    - Strategy for producing and persisting different OpenAPI bundle snapshots over time.
+    - Potentially more comprehensive testing.
+    - Further UI/UX enhancements on the frontend.
+    - Scalability and performance optimizations as the user base grows.
+
+## Current Status
+
+- The Memory Bank has been initialized and populated with initial project context based on `README.md` and user input.
+- The next immediate task is to discuss, plan, and implement the "likes" feature.
+
+## Known Issues
+
+- No specific issues identified from the provided context, apart from the "missing feature" of OpenAPI bundle snapshotting.
+
+## Evolution of Project Decisions
+
+- **Initial Decision:** Adopt OpenAPI for API design to ensure consistency and enable code generation.
+- **Initial Decision:** Structure the project with a Go backend and React frontend.
+- **Initial Decision:** Use PostgreSQL as the database.
+- **Initial Decision:** Implement API versioning from the start (e.g., `/v1/`).
+- **Current State:** The project has followed these initial decisions and established a solid foundation. The focus is now shifting towards adding new features like "likes" and considering longer-term improvements like OpenAPI snapshot management.

--- a/memory-bank/projectbrief.md
+++ b/memory-bank/projectbrief.md
@@ -1,0 +1,25 @@
+# Project Brief
+
+## Core Requirements
+
+- Social media application with Go backend and React frontend.
+- Features for users to create posts, comment on posts, and interact.
+- Follows OpenAPI specification for API design.
+- API versioning to avoid breaking changes.
+
+## Goals
+
+- Provide a robust and scalable social media platform.
+- Maintain a clear and consistent API contract using OpenAPI.
+- Enable future expansion for client applications beyond the current frontend.
+- Implement new features such as "likes" for posts/comments.
+- Develop a strategy for producing and persisting different OpenAPI bundle snapshots.
+
+## Scope
+
+- Backend development in Go (Chi Router, PostgreSQL).
+- Frontend development in React (TypeScript, Vite, Tailwind CSS, Shadcn/ui, Zustand, React Query).
+- Database migrations using golang-migrate.
+- API definition and code generation based on OpenAPI specs.
+- Initial focus on implementing a "likes" feature.
+- Future consideration for OpenAPI bundle snapshotting.

--- a/memory-bank/projectbrief.md
+++ b/memory-bank/projectbrief.md
@@ -12,14 +12,22 @@
 - Provide a robust and scalable social media platform.
 - Maintain a clear and consistent API contract using OpenAPI.
 - Enable future expansion for client applications beyond the current frontend.
-- Implement new features such as "likes" for posts/comments.
-- Develop a strategy for producing and persisting different OpenAPI bundle snapshots.
+- Define OpenAPI specifications for new features, starting with "likes".
+- Implement new features (backend and frontend) based on defined OpenAPI specs (future work).
+- Develop a strategy for producing and persisting different OpenAPI bundle snapshots (future work).
 
 ## Scope
 
-- Backend development in Go (Chi Router, PostgreSQL).
-- Frontend development in React (TypeScript, Vite, Tailwind CSS, Shadcn/ui, Zustand, React Query).
-- Database migrations using golang-migrate.
-- API definition and code generation based on OpenAPI specs.
-- Initial focus on implementing a "likes" feature.
-- Future consideration for OpenAPI bundle snapshotting.
+- **Current Task:** Define the OpenAPI specification for a "likes" feature. This includes:
+    - Creating or updating relevant YAML partials for paths and schemas.
+    - Updating the main `openapi.yaml` file.
+    - Generating the `openapi-bundled.yaml` and verifying its correctness in Swagger UI.
+- **Out of Scope for Current Task:**
+    - Implementation of backend logic for the "likes" feature.
+    - Implementation of frontend UI/logic for the "likes" feature.
+    - Developing the strategy for OpenAPI bundle snapshotting.
+- **Overall Project Scope (includes future work):**
+    - Backend development in Go (Chi Router, PostgreSQL).
+    - Frontend development in React (TypeScript, Vite, Tailwind CSS, Shadcn/ui, Zustand, React Query).
+    - Database migrations using golang-migrate.
+    - Full API lifecycle management based on OpenAPI specs (definition, code generation, implementation).

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -1,0 +1,41 @@
+# System Patterns
+
+## System Architecture
+
+- **Monolithic Backend:** Go application serving API endpoints.
+- **Single Page Application (SPA) Frontend:** React application consuming the API.
+- **Database:** PostgreSQL for data persistence.
+- **API Layer:** Defined by OpenAPI, acts as the contract between backend and frontend.
+
+## Key Technical Decisions
+
+- **OpenAPI-first approach:** The API specification (`openapi.yaml` and partials) is the source of truth.
+- **Code Generation:** Go types (`internal/generated/types.go`) and TypeScript types (`frontend/src/generated/api-types.ts`) are generated from the OpenAPI spec. This ensures consistency and reduces manual type definition.
+- **API Versioning:** Paths are prefixed with `/v1/`, allowing for future API evolution without breaking existing clients.
+- **Structured Error Responses:** Consistent error format (`{"errors": [{"code": "...", "message": "...", "field": "..."}]}`) for all API endpoints.
+- **Structured Success Responses:** Consistent success format (`{"data": {...}}`) for all API endpoints.
+- **Use of Partials for OpenAPI:** Specification is broken down into smaller, manageable YAML files (in `openapi/shared/` and `openapi/v1/`) and bundled into `openapi/openapi-bundled.yaml` using `@redocly/cli`.
+
+## Design Patterns in Use
+
+- **Facade Pattern:**
+    - Backend: `internal/apitypes/types.go` re-exports types from `internal/generated`, decoupling service logic from generated code.
+    - Frontend: `frontend/src/types/api.ts` re-exports types from `frontend/src/generated/api-types.ts`, decoupling components/services from generated code.
+- **Repository Pattern (implied):** The backend likely uses repositories for database interactions (e.g., `internal/repositories/`).
+- **Service Layer (implied):** Business logic is likely encapsulated in services (e.g., `internal/services/`).
+- **Middleware (explicit):** Chi router is used, which supports middleware for concerns like authentication (`cmd/middlewares/auth_middleware.go`).
+
+## Component Relationships
+
+- **Frontend (`frontend/`)** depends on **Backend API**.
+- **Backend API (`cmd/api/`)** depends on **Services (`internal/services/`)**.
+- **Services (`internal/services/`)** depend on **Repositories (`internal/repositories/`)** and **Domain Models (`internal/domain/`)**.
+- **Repositories (`internal/repositories/`)** depend on **Database (`cmd/database/db.go`)** and **Domain Models (`internal/domain/`)**.
+- **OpenAPI Specification (`openapi/`)** is used by code generation tools to produce types for both **Backend (`internal/generated/`)** and **Frontend (`frontend/src/generated/`)**.
+
+## Critical Implementation Paths
+
+- **Authentication Flow:** Signup, login, logout, token refresh. Involves JWTs and secure handling of credentials.
+- **Post Creation/Management:** Creating, reading, updating, deleting posts.
+- **Comment Creation/Management:** Creating, reading, updating, deleting comments on posts.
+- **API Spec Modification and Type Regeneration:** Any change to an API requires updating the OpenAPI YAML files, re-bundling, and re-generating Go and TypeScript types using `make generate-types`.

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -1,0 +1,85 @@
+# Tech Context
+
+## Technologies Used
+
+- **Backend:**
+    - Go (version specified in `go.mod`)
+    - Chi Router (for HTTP routing)
+    - PostgreSQL (database)
+- **Frontend:**
+    - React
+    - TypeScript
+    - Vite (build tool and dev server)
+    - Tailwind CSS (styling)
+    - Shadcn/ui (UI components)
+    - Zustand (state management)
+    - React Query (data fetching and caching)
+    - Vitest (unit/integration testing)
+    - MSW (Mock Service Worker for API mocking in tests)
+- **Database Migrations:**
+    - golang-migrate (CLI tool)
+- **Development Environment:**
+    - Docker & Docker Compose (for running PostgreSQL and potentially other services)
+    - Air (optional, for Go backend live reload)
+    - Node.js (version specified in `frontend/package.json` or latest LTS)
+    - npm (for frontend dependency management)
+- **API Specification:**
+    - OpenAPI 3
+    - YAML
+
+## Development Setup
+
+- **Prerequisites:** Go, Node.js, npm, Docker, Docker Compose, Golang Migrate CLI, Air (optional).
+- **Installation:**
+    1. Clone repository.
+    2. `go mod tidy` for backend dependencies.
+    3. `cd frontend && npm install` for frontend dependencies.
+- **Environment Variables:**
+    - Backend: `.env.local` (from `.env.local.example`) for DB connection, JWT secret.
+    - Frontend: `frontend/.env.development` and `frontend/.env.production` (from `frontend/.env.example`) for `VITE_API_BASE_URL`.
+- **Database:** Start PostgreSQL using `docker compose up -d`.
+- **Migrations:** Run using `make migrate-up`.
+- **Running the Application:**
+    - Concurrently (backend & frontend): `make dev`
+    - Backend only (with Air): `air`
+    - Backend only (standard): `make dev-be` or `go run ./cmd/main.go`
+    - Frontend only: `make dev-fe` or `cd frontend && npm run dev`
+
+## Technical Constraints
+
+- Backend and frontend types must be kept in sync with the OpenAPI specification.
+- Adherence to the defined API response structure (success with `data`, error with `errors`).
+- Go tools managed via `go.mod` and `tools.go`.
+- Node.js tools managed via `frontend/package.json`.
+
+## Dependencies
+
+- **Backend (Key Go Modules - see `go.mod` for full list):**
+    - `github.com/go-chi/chi/v5`
+    - `github.com/jackc/pgx/v5` (PostgreSQL driver)
+    - `github.com/golang-jwt/jwt/v5`
+    - `github.com/deepmap/oapi-codegen` (for code generation, via `tools.go`)
+- **Frontend (Key NPM Packages - see `frontend/package.json` for full list):**
+    - `react`, `react-dom`
+    - `typescript`
+    - `vite`
+    - `tailwindcss`
+    - `@radix-ui/*` (used by Shadcn/ui)
+    - `zustand`
+    - `@tanstack/react-query`
+    - `vitest`, `msw`
+    - `openapi-typescript` (for code generation)
+    - `@redocly/cli` (for OpenAPI bundling)
+
+## Tool Usage Patterns
+
+- **`make`:** Centralized script for common development tasks (running dev servers, tests, migrations, code generation). See `Makefile`.
+- **`go mod tidy`:** To manage Go dependencies.
+- **`npm install` (in `frontend/`):** To manage frontend dependencies.
+- **`docker compose`:** To manage services like PostgreSQL.
+- **`golang-migrate`:** For database schema migrations.
+- **`air`:** For live reloading of the Go backend during development.
+- **`oapi-codegen`:** Generates Go types from `openapi-bundled.yaml`. Invoked via `make generate-types`.
+- **`openapi-typescript`:** Generates TypeScript types from `openapi-bundled.yaml`. Invoked via `make generate-types`.
+- **`@redocly/cli bundle`:** Bundles partial OpenAPI YAML files into `openapi-bundled.yaml`. Invoked via `make generate-types`.
+- **Swagger UI:** Served by the backend at `/api/docs` for interactive API exploration.

--- a/openapi/openapi-bundled.yaml
+++ b/openapi/openapi-bundled.yaml
@@ -1014,6 +1014,62 @@ components:
             $ref: '#/components/schemas/Comment'
       required:
         - data
+    Like:
+      type: object
+      description: Represents a user's like on a post or comment. One of post_id or comment_id should be populated.
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: Unique identifier for the like.
+          readOnly: true
+          example: 1001
+        user_id:
+          type: integer
+          format: int64
+          description: ID of the user who liked the content.
+          readOnly: true
+          example: 101
+        post_id:
+          type: integer
+          format: int64
+          description: ID of the post being liked (mutually exclusive with comment_id).
+          nullable: true
+          example: 201
+        comment_id:
+          type: integer
+          format: int64
+          description: ID of the comment being liked (mutually exclusive with post_id).
+          nullable: true
+          example: 301
+        created_at:
+          type: string
+          format: date-time
+          description: Timestamp when the like was created.
+          readOnly: true
+          example: '2024-03-10T10:30:00Z'
+      required:
+        - id
+        - user_id
+        - created_at
+    CreateLikeSuccessResponse:
+      type: object
+      description: Standard wrapper for the successful like creation response.
+      properties:
+        data:
+          $ref: '#/components/schemas/Like'
+      required:
+        - data
+    ListLikesSuccessResponse:
+      type: object
+      description: Standard wrapper for listing likes.
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Like'
+      required:
+        - data
     SignupSuccessResponse:
       type: object
       description: Standard wrapper for the successful signup response.

--- a/openapi/openapi-bundled.yaml
+++ b/openapi/openapi-bundled.yaml
@@ -15,6 +15,8 @@ tags:
     description: Operations related to posts (Version 1)
   - name: Comments V1
     description: Operations related to comments (Version 1)
+  - name: Likes V1
+    description: Operations related to likes on posts and comments (Version 1)
 paths:
   /v1/auth/signup:
     post:
@@ -623,6 +625,226 @@ paths:
                 $ref: '#/components/schemas/ApiErrorResponse'
         '500':
           description: Server error deleting comment.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+  /v1/posts/{postId}/likes:
+    parameters:
+      - name: postId
+        in: path
+        required: true
+        description: The ID of the post.
+        schema:
+          type: integer
+          format: int64
+    get:
+      tags:
+        - Likes V1
+      summary: List likes for a post
+      description: Retrieves a list of likes for a specific post.
+      operationId: listPostLikesV1
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: A list of likes retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListLikesSuccessResponse'
+        '401':
+          description: Authentication required or invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '404':
+          description: Post not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '500':
+          description: Server error retrieving likes.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+    post:
+      tags:
+        - Likes V1
+      summary: Like a post
+      description: Creates a new like on a specific post for the authenticated user.
+      operationId: createPostLikeV1
+      security:
+        - bearerAuth: []
+      responses:
+        '201':
+          description: Post liked successfully. Returns the created like object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateLikeSuccessResponse'
+        '401':
+          description: Authentication required or invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '404':
+          description: Post not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '409':
+          description: Post already liked by the user or other conflict.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '500':
+          description: Server error creating like.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+    delete:
+      tags:
+        - Likes V1
+      summary: Unlike a post
+      description: Removes the authenticated user's like from a specific post.
+      operationId: deletePostLikeV1
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Post unliked successfully. No content returned.
+        '401':
+          description: Authentication required or invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '404':
+          description: Post not found or like not found for the user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '500':
+          description: Server error deleting like.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+  /v1/comments/{commentId}/likes:
+    parameters:
+      - name: commentId
+        in: path
+        required: true
+        description: The ID of the comment.
+        schema:
+          type: integer
+          format: int64
+    get:
+      tags:
+        - Likes V1
+      summary: List likes for a comment
+      description: Retrieves a list of likes for a specific comment.
+      operationId: listCommentLikesV1
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: A list of likes retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListLikesSuccessResponse'
+        '401':
+          description: Authentication required or invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '404':
+          description: Comment not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '500':
+          description: Server error retrieving likes.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+    post:
+      tags:
+        - Likes V1
+      summary: Like a comment
+      description: Creates a new like on a specific comment for the authenticated user.
+      operationId: createCommentLikeV1
+      security:
+        - bearerAuth: []
+      responses:
+        '201':
+          description: Comment liked successfully. Returns the created like object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateLikeSuccessResponse'
+        '401':
+          description: Authentication required or invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '404':
+          description: Comment not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '409':
+          description: Comment already liked by the user or other conflict.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '500':
+          description: Server error creating like.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+    delete:
+      tags:
+        - Likes V1
+      summary: Unlike a comment
+      description: Removes the authenticated user's like from a specific comment.
+      operationId: deleteCommentLikeV1
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Comment unliked successfully. No content returned.
+        '401':
+          description: Authentication required or invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '404':
+          description: Comment not found or like not found for the user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '500':
+          description: Server error deleting like.
           content:
             application/json:
               schema:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -37,6 +37,11 @@ paths:
     $ref: './v1/paths/comment.yaml#/paths/~1v1~1posts~1{postId}~1comments'
   /v1/posts/{postId}/comments/{id}: # Add reference to the single comment path
     $ref: './v1/paths/comment.yaml#/paths/~1v1~1posts~1{postId}~1comments~1{id}'
+  # New Path References for Likes
+  /v1/posts/{postId}/likes:
+    $ref: './v1/paths/like.yaml#/paths/~1v1~1posts~1{postId}~1likes'
+  /v1/comments/{commentId}/likes:
+    $ref: './v1/paths/like.yaml#/paths/~1v1~1comments~1{commentId}~1likes'
 
 
 components:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -16,6 +16,8 @@ tags:
     description: Operations related to posts (Version 1)
   - name: Comments V1
     description: Operations related to comments (Version 1)
+  - name: Likes V1 # New Tag
+    description: Operations related to likes on posts and comments (Version 1)
 
 paths:
   # References to path definitions in ./v1/paths/ will go here

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -89,6 +89,13 @@ components:
       $ref: './v1/schemas/comment.yaml#/components/schemas/UpdateCommentSuccessResponse'
     ListCommentsSuccessResponse:
       $ref: './v1/schemas/comment.yaml#/components/schemas/ListCommentsSuccessResponse'
+    # New Schema References for Likes
+    Like:
+      $ref: './v1/schemas/like.yaml#/components/schemas/Like'
+    CreateLikeSuccessResponse:
+      $ref: './v1/schemas/like.yaml#/components/schemas/CreateLikeSuccessResponse'
+    ListLikesSuccessResponse:
+      $ref: './v1/schemas/like.yaml#/components/schemas/ListLikesSuccessResponse'
 
 
   securitySchemes: # Define security schemes if needed (e.g., JWT)

--- a/openapi/v1/paths/like.yaml
+++ b/openapi/v1/paths/like.yaml
@@ -7,8 +7,8 @@ paths:
         required: true
         description: The ID of the post.
         schema:
-          type: integer # Changed from string
-          format: int64  # Added format
+          type: integer
+          format: int64
     get:
       tags:
         - Likes V1
@@ -23,25 +23,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListLikesSuccessResponse'
+                $ref: '../schemas/like.yaml#/components/schemas/ListLikesSuccessResponse'
         '401':
           description: Authentication required or invalid token.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
         '404':
           description: Post not found.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
         '500':
           description: Server error retrieving likes.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
     post:
       tags:
         - Likes V1
@@ -56,31 +56,31 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreateLikeSuccessResponse'
+                $ref: '../schemas/like.yaml#/components/schemas/CreateLikeSuccessResponse'
         '401':
           description: Authentication required or invalid token.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
         '404':
           description: Post not found.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
         '409':
           description: Post already liked by the user or other conflict.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
         '500':
           description: Server error creating like.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
     delete:
       tags:
         - Likes V1
@@ -97,19 +97,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
         '404':
           description: Post not found or like not found for the user.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
         '500':
           description: Server error deleting like.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
 
   /v1/comments/{commentId}/likes:
     parameters:
@@ -118,8 +118,8 @@ paths:
         required: true
         description: The ID of the comment.
         schema:
-          type: integer # Changed from string
-          format: int64  # Added format
+          type: integer
+          format: int64
     get:
       tags:
         - Likes V1
@@ -134,25 +134,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ListLikesSuccessResponse'
+                $ref: '../schemas/like.yaml#/components/schemas/ListLikesSuccessResponse'
         '401':
           description: Authentication required or invalid token.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
         '404':
           description: Comment not found.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
         '500':
           description: Server error retrieving likes.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
     post:
       tags:
         - Likes V1
@@ -167,31 +167,31 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CreateLikeSuccessResponse'
+                $ref: '../schemas/like.yaml#/components/schemas/CreateLikeSuccessResponse'
         '401':
           description: Authentication required or invalid token.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
         '404':
           description: Comment not found.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
         '409':
           description: Comment already liked by the user or other conflict.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
         '500':
           description: Server error creating like.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
     delete:
       tags:
         - Likes V1
@@ -208,16 +208,16 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
         '404':
           description: Comment not found or like not found for the user.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'
         '500':
           description: Server error deleting like.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ApiErrorResponse'
+                $ref: '../../shared/schemas/common.yaml#/components/schemas/ApiErrorResponse'

--- a/openapi/v1/paths/like.yaml
+++ b/openapi/v1/paths/like.yaml
@@ -1,0 +1,223 @@
+# openapi/v1/paths/like.yaml
+paths:
+  /v1/posts/{postId}/likes:
+    parameters:
+      - name: postId
+        in: path
+        required: true
+        description: The ID of the post.
+        schema:
+          type: integer # Changed from string
+          format: int64  # Added format
+    get:
+      tags:
+        - Likes V1
+      summary: List likes for a post
+      description: Retrieves a list of likes for a specific post.
+      operationId: listPostLikesV1
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: A list of likes retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListLikesSuccessResponse'
+        '401':
+          description: Authentication required or invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '404':
+          description: Post not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '500':
+          description: Server error retrieving likes.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+    post:
+      tags:
+        - Likes V1
+      summary: Like a post
+      description: Creates a new like on a specific post for the authenticated user.
+      operationId: createPostLikeV1
+      security:
+        - bearerAuth: []
+      responses:
+        '201':
+          description: Post liked successfully. Returns the created like object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateLikeSuccessResponse'
+        '401':
+          description: Authentication required or invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '404':
+          description: Post not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '409':
+          description: Post already liked by the user or other conflict.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '500':
+          description: Server error creating like.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+    delete:
+      tags:
+        - Likes V1
+      summary: Unlike a post
+      description: Removes the authenticated user's like from a specific post.
+      operationId: deletePostLikeV1
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Post unliked successfully. No content returned.
+        '401':
+          description: Authentication required or invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '404':
+          description: Post not found or like not found for the user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '500':
+          description: Server error deleting like.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+
+  /v1/comments/{commentId}/likes:
+    parameters:
+      - name: commentId
+        in: path
+        required: true
+        description: The ID of the comment.
+        schema:
+          type: integer # Changed from string
+          format: int64  # Added format
+    get:
+      tags:
+        - Likes V1
+      summary: List likes for a comment
+      description: Retrieves a list of likes for a specific comment.
+      operationId: listCommentLikesV1
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: A list of likes retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListLikesSuccessResponse'
+        '401':
+          description: Authentication required or invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '404':
+          description: Comment not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '500':
+          description: Server error retrieving likes.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+    post:
+      tags:
+        - Likes V1
+      summary: Like a comment
+      description: Creates a new like on a specific comment for the authenticated user.
+      operationId: createCommentLikeV1
+      security:
+        - bearerAuth: []
+      responses:
+        '201':
+          description: Comment liked successfully. Returns the created like object.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateLikeSuccessResponse'
+        '401':
+          description: Authentication required or invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '404':
+          description: Comment not found.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '409':
+          description: Comment already liked by the user or other conflict.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '500':
+          description: Server error creating like.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+    delete:
+      tags:
+        - Likes V1
+      summary: Unlike a comment
+      description: Removes the authenticated user's like from a specific comment.
+      operationId: deleteCommentLikeV1
+      security:
+        - bearerAuth: []
+      responses:
+        '204':
+          description: Comment unliked successfully. No content returned.
+        '401':
+          description: Authentication required or invalid token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '404':
+          description: Comment not found or like not found for the user.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '500':
+          description: Server error deleting like.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'

--- a/openapi/v1/schemas/like.yaml
+++ b/openapi/v1/schemas/like.yaml
@@ -1,0 +1,61 @@
+# openapi/v1/schemas/like.yaml
+components:
+  schemas:
+    Like:
+      type: object
+      description: Represents a user's like on a post or comment. One of post_id or comment_id should be populated.
+      properties:
+        id:
+          type: integer # Changed from string
+          format: int64  # Added format
+          description: Unique identifier for the like.
+          readOnly: true
+          example: 1001    # Changed example
+        user_id:
+          type: integer # Changed from string
+          format: int64  # Added format
+          description: ID of the user who liked the content.
+          readOnly: true # Set by the backend based on authenticated user.
+          example: 101     # Changed example
+        post_id:
+          type: integer # Changed from string
+          format: int64  # Added format
+          description: ID of the post being liked (mutually exclusive with comment_id).
+          nullable: true
+          example: 201     # Changed example
+        comment_id:
+          type: integer # Changed from string
+          format: int64  # Added format
+          description: ID of the comment being liked (mutually exclusive with post_id).
+          nullable: true
+          example: 301     # Changed example
+        created_at:
+          type: string
+          format: date-time
+          description: Timestamp when the like was created.
+          readOnly: true
+          example: '2024-03-10T10:30:00Z'
+      required:
+        - id
+        - user_id
+        - created_at
+
+    CreateLikeSuccessResponse:
+      type: object
+      description: Standard wrapper for the successful like creation response.
+      properties:
+        data:
+          $ref: '#/components/schemas/Like'
+      required:
+        - data
+
+    ListLikesSuccessResponse:
+      type: object
+      description: Standard wrapper for listing likes.
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Like'
+      required:
+        - data


### PR DESCRIPTION
## Problem Statement

We have a working OpenAPI spec for a Social Network app and we want to introduce a new resource: “Likes”


## Prompts used

### Step 1- Define the initial task to perform

- first init the memory bank:
```
initialize memory bank
```
- then provide the task details:
```
This project contains a @/README.md that provides an overview over what it is. There is a backend in Golang and a Frontend in React.

One important aspect of this project is that it follows OpenAPI specification to design and provide standards around how the endpoints are built and what contracts are exposed to the user, which in our case for now is only the Frontend.

However, in the future we can consider exposing these endpoints to clients too (we are already following a versioning convention to avoid breaking changes).

The spec are defined in @/openapi - we write partials that are then recomposed to gether to generate a final spec, the latest one is @/openapi/openapi-bundled.yaml 

We have not yet implemented a strategy on how to produce and persist different bundles that can represent snapshots of our API spec at different point in time. This will be needed and is a missing feature to implement in the future.

A more immediate requirement we have, is the definition of a new endpoint. This endpoint should expose "likes".

I have shared a lot of context with you so far, some of which I believe should be saved in our memory bank. 
Regarding the new endpoint implementation, let's begin a discussion on how it should be structured - keeping in mind we can lean on the existing patterns and conventions of the existing openapi spec.
```

- Chunk the plan to avoid scope creep

```
The context you saved and identified appears mostly correct. However we need to adjust the Next steps:

"Complete updates for systemPatterns.md, techContext.md, and progress.md.
Discuss the requirements and design for the new "likes" endpoint.
Define the OpenAPI specification for the "likes" endpoint.
Implement the backend logic for "likes".
Implement the frontend UI and logic for "likes"."

The implementation of the feature should be out of scope - we are only interested in the endpoint API Spec at this stage, and we consider this work "Done" once we have a valid OpenAPI spec that we can load to our current Swagger UI. The Swagger UI is already functional and will automatically pick updates to the spec.

Implement versioning of the bundled spec is also out of scope for now.

Let's update our plan to reflect these requirements.
```


### Step 2 - Review and commit the final plan in memory

```
I would like the likes endpoint to follow the current REST conventions of the project. The Likes data model should have the following shape:

\```go
// Like represents a user's like on a post or comment.
type Like struct {
	ID        string    `json:"id"`         // Unique identifier for the like
	UserID    string    `json:"user_id"`    // ID of the user who liked the content
	PostID    *string   `json:"post_id,omitempty"`   // ID of the post being liked (nullable)
	CommentID *string   `json:"comment_id,omitempty"` // ID of the comment being liked (nullable)
	CreatedAt time.Time `json:"created_at"` // Timestamp when the like was created
}
\```

 PostID and CommentID are made nullable (using pointers in Go, *string) because a single Like entry represents a user liking either a post or a comment, but not both simultaneously.


Generate an initial spec that we can discuss and iterate together
```

```
Can we add this plan to the memory bank so that I can review it across contexes to make sure we are making the right decisions?
```

### Step 3 - Provide feedback on the plan
```
Your proposal raises important questions here:

**Discussion Points for this Proposal:**
1.  **ID Types:** Confirm if `Like` related IDs (`id`, `user_id`, `post_id`, `comment_id`) should be `string` (as per Go struct) or `integer` (like other entities).
2.  **Listing Likes Content:** Is an array of full `Like` objects suitable for `GET` requests, or would a list of user IDs/count be preferred in some cases?
3.  **Common Error Responses:** Ensure `#/components/responses/*` refs point to correctly defined shared responses.

1. Stick to integer for consistency - these are PSQL auto-incrementing integers
2. Let's have an array of likes as object.
3. You should use the existing schema. If an existing schema doesn't exist, we should introduce one that is backwards compatible with the existing specs.

Update the plan based on my feedback.
```

### Step 5 - Review initial implementation and help with troubleshooting

```
It looks good, but I don't see the new paths exposed in Swagger UI - I suspect it might have something to do with @/openapi/openapi.yaml not having the new `paths` linked correctly?
```

### Step 6 - Confirm details of plan to fix issues

```
Your plan looks good, but before we begin, I want to make sure our memory bank is up to date with the state of our progress.
```

### Step 7 - Confirm task completion

```
I consider the task completed. We can update our memory bank
```